### PR TITLE
use pydantic models + missing title in TTS bug fix + cleanup

### DIFF
--- a/examples/cli_example.py
+++ b/examples/cli_example.py
@@ -37,8 +37,7 @@ def main():
     results = run_generation(topic, num_lectures, do_generate_audio)
 
     print("Lecture series generation complete.")
-    print(f"Lecture series text: {results['aggregate_path']}")
-    print(f"Lecture series outline: {results['outline_path']}")
+    print(f"Lecture series text: {results['series_text_path']}")
     if do_generate_audio:
         print(f"Lecture series audio: {results['audio_path']}")
     print(f"Total generation time: {format_time(results['total_time'])}")

--- a/src/okcourse/__init__.py
+++ b/src/okcourse/__init__.py
@@ -1,3 +1,13 @@
 from .okcourse import NUM_LECTURES, run_generation, format_time, sanitize_filename
+from .models import Lecture, LectureSeries, LectureSeriesOutline, LectureTopic
 
-__all__ = ["NUM_LECTURES", "run_generation", "format_time", "sanitize_filename"]
+__all__ = [
+    "NUM_LECTURES",
+    "run_generation",
+    "format_time",
+    "sanitize_filename",
+    "Lecture",
+    "LectureSeries",
+    "LectureSeriesOutline",
+    "LectureTopic",
+]

--- a/src/okcourse/models.py
+++ b/src/okcourse/models.py
@@ -2,19 +2,35 @@ from pydantic import BaseModel, Field
 
 
 class LectureTopic(BaseModel):
+    number: int = Field(..., description="The position number of the lecture within the series.")
     title: str = Field(..., description="The topic of a lecture within a lecture series.")
     subtopics: list[str] = Field(..., description="The subtopics covered in the lecture.")
+
+    def __str__(self) -> str:
+        subtopics_str = "\n".join(f"  - {sub}" for sub in self.subtopics) if self.subtopics else ""
+        return f"Lecture {self.number}: {self.title}\n{subtopics_str}"
 
 
 class LectureSeriesOutline(BaseModel):
     title: str = Field(..., description="The title of the lecture series.")
     topics: list[LectureTopic] = Field(..., description="The topics covered by each lecture in the series.")
 
+    def __str__(self) -> str:
+        topics_str = "\n\n".join(str(topic) for topic in self.topics)
+        return f"Lecture Series: {self.title}\n\n{topics_str}"
+
 
 class Lecture(LectureTopic):
-    text: str = Field(..., description="The unabridge text content of the lecture.")
+    text: str = Field(..., description="The unabridged text content of the lecture.")
+
+    def __str__(self) -> str:
+        return f"{self.title}\n\n{self.text}"
 
 
 class LectureSeries(BaseModel):
-    outline: LectureSeriesOutline = Field(..., "The detailed outline of the lecture series.")
-    lectures: list[Lecture] = Field(..., "The lectures that comprise the complete lecture series.")
+    outline: LectureSeriesOutline = Field(..., description="The detailed outline of the lecture series.")
+    lectures: list[Lecture] = Field(..., description="The lectures that comprise the complete lecture series.")
+
+    def __str__(self) -> str:
+        lectures_str = "\n\n".join(str(lecture) for lecture in self.lectures)
+        return f"{self.outline}\n\n{lectures_str}"

--- a/src/okcourse/okcourse.py
+++ b/src/okcourse/okcourse.py
@@ -3,13 +3,14 @@ import logging
 import re
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import dataclass
 from datetime import timedelta
 from pathlib import Path
 
 import nltk
 from openai import OpenAI
 from pydub import AudioSegment
+
+from .models import Lecture, LectureSeries, LectureSeriesOutline
 
 NUM_LECTURES = 20
 TEXT_MODEL = "gpt-4o"
@@ -25,6 +26,12 @@ SYSTEM_PROMPT = (
     "Your lecture style is professional, direct, and highly technical."
 )
 
+WORD_SWAPS = {
+    "delve": "dig",
+    "crucial": "important",
+    "utilize": "use",
+}
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
@@ -33,21 +40,6 @@ logging.basicConfig(
 log = logging.getLogger()
 
 llm_client = OpenAI()
-
-
-@dataclass
-class Lecture:
-    """Represents a lecture in the series.
-
-    Attributes:
-        number: The lecture number in the series.
-        title: The lecture title.
-        text: The full lecture text content.
-    """
-
-    number: int
-    title: str
-    text: str
 
 
 def sanitize_filename(name: str) -> str:
@@ -83,7 +75,24 @@ def format_time(seconds: float) -> str:
     return f"{m}:{s:02}"
 
 
-def generate_lecture_series_outline(topic: str, num_lectures: int) -> str:
+def swap_words(text: str, swaps: dict[str, str]) -> str:
+    """Swaps words in the given text.
+
+    Args:
+        text: The text to process.
+        swaps: A dictionary of words to replace (keys) and their replacements (values).
+
+    Returns:
+        The text with swaps applied.
+    """
+    # Matches all keys as whole words
+    pattern = r'\b(' + '|'.join(re.escape(word) for word in swaps.keys()) + r')\b'
+
+    # Replace each match with its corresponding value from the swaps dictionary
+    return re.sub(pattern, lambda match: swaps[match.group(0)], text)
+
+
+def generate_lecture_series_outline(topic: str, num_lectures: int) -> LectureSeriesOutline:
     """Given the topic for a series of lectures, generates a series outline using OpenAI.
 
     Args:
@@ -91,26 +100,30 @@ def generate_lecture_series_outline(topic: str, num_lectures: int) -> str:
         num_lectures: The number of lectures that should be in the series.
 
     Returns:
-        A detailed lecture outline.
+        A detailed lecture outline in a Pydantic model instance.
     """
-    prompt = (
+    outline_prompt = (
         f"Provide a detailed outline for a {num_lectures}-part lecture series for a graduate-level course on "
         f"'{topic}'. List each lecture title numbered. Each lecture should have four subtopics listed after the "
         "lecture title. Respond only with the outline, omitting any other commentary."
     )
 
-    log.info("Requesting lecture outline from LLM...")
-    response = llm_client.chat.completions.create(
+    log.info("Requesting lecture series outline from LLM...")
+    series_completion = llm_client.beta.chat.completions.parse(
         model=TEXT_MODEL,
         messages=[
             {"role": "system", "content": SYSTEM_PROMPT},
-            {"role": "user", "content": prompt},
+            {"role": "user", "content": outline_prompt},
         ],
+        response_format=LectureSeriesOutline,
     )
+    series_outline = series_completion.choices[0].message.parsed
 
-    lecture_outline = response.choices[0].message.content
+    # Reset the topic to exactly what was passed in since the LLM tends to add its own subtitle.
+    log.info(f"Resetting lecture series topic to '{topic}' from LLM-provided '{series_outline.title}'")
+    series_outline.title = topic
 
-    return lecture_outline
+    return series_outline
 
 
 def get_lecture_titles_from_outline(outline: str) -> list[str]:
@@ -132,30 +145,32 @@ def get_lecture_titles_from_outline(outline: str) -> list[str]:
     return lecture_titles
 
 
-def get_lecture(topic: str, lecture_title: str, outline: str, idx: int) -> Lecture:
-    """Generates the text content for a single lecture.
+def get_lecture(series_outline: LectureSeriesOutline, lecture_number: int) -> Lecture:
+    """Generates a lecture for the topic with the specified number in the given outline.
 
     Args:
-        topic: The topic of the lecture series.
-        lecture_title: The title of this specific lecture.
-        outline: The full lecture series outline.
-        idx: The lecture number.
+        outline: The outline of the lecture series containing lecture topics and their subtopics.
+        number: The position number of the lecture to generate.
 
     Returns:
-        A Lecture instance containing the generated lecture content.
+        A Lecture object representing the lecture for the given number.
     """
+    topic = next((t for t in series_outline.topics if t.number == lecture_number), None)
+    if not topic:
+        raise ValueError(f"No topic found for lecture number {lecture_number}")
     prompt = (
-        f"Generate the text for a lengthy lecture titled '{lecture_title}' in a lecture series on '{topic}'. "
-        "The lecture should be written in the style of a Great Courses audiobook by the Learning Company and should "
-        "cover the topic in great detail. "
+        f"Generate the text for a lengthy lecture titled '{topic.title}' in a lecture series on "
+        "'{series_outline.title}'. The lecture should be written in the style of a Great Courses audiobook by the "
+        "Learning Company and should cover the topic in great detail. "
         "Omit Markdown from the lecture text as well as any tags, formatting markers, or headings that might interfere "
-        "with text-to-speech processing. Omit temporal references to the lecture, as well as references "
-        "to yourself or the audience. "
+        "with text-to-speech processing. "
         "Ensure the content is original and does not duplicate content from the other lectures in the series.\n"
-        f"Lecture Series Outline:\n{outline}"
+        f"Lecture Series Outline:\n{series_outline}"
     )
 
-    log.info(f"Requesting lexture text from LLM for '{lecture_title}'...")
+    log.info(
+        f"Requesting lecture text from LLM for topic {topic.number}/{len(series_outline.topics)}: {topic.title}..."
+    )
     response = llm_client.chat.completions.create(
         model=TEXT_MODEL,
         messages=[
@@ -164,71 +179,51 @@ def get_lecture(topic: str, lecture_title: str, outline: str, idx: int) -> Lectu
         ],
     )
     lecture_text = response.choices[0].message.content.strip()
+    lecture_text = swap_words(lecture_text, WORD_SWAPS)
 
-    log.info(f"Got lexture text from LLM for '{lecture_title}'...")
-    return Lecture(idx, lecture_title, lecture_text)
+    log.info(f"Got lexture text from LLM for '{topic.title}'...")
+    return Lecture(**topic.model_dump(), text=lecture_text)
 
 
-def get_lectures(lecture_titles: list[str], topic: str, outline_text: str) -> list[Lecture]:
-    """Generates the text of the lectures in the given lecture series outline.
+def get_lectures(series_outline: LectureSeriesOutline) -> LectureSeries:
+    """Generates the text for the lectures in the given lecture series outline.
 
     Args:
-        lecture_titles: A list of lecture titles.
-        topic: The topic of the lecture series.
-        outline_text: The full outline text of the lecture series.
+        series_outline: The outline of the lecture series for which to generate lectures.
 
     Returns:
-        A list of Lecture instances.
+        The complete lecture series containing all the lectures.
     """
-    lectures = []
     with ThreadPoolExecutor() as executor:
-        futures = {
-            executor.submit(get_lecture, topic, title, outline_text, idx): idx
-            for idx, title in enumerate(lecture_titles, start=1)
-        }
-        for future in as_completed(futures):
-            lecture = future.result()
-            lectures.append(lecture)
-    lectures.sort(key=lambda lec: lec.number)
-    return lectures
+        lectures = list(
+            executor.map(
+                # Use a lambda here to provide both the outline and lecture number
+                lambda topic: get_lecture(series_outline, topic.number),
+                series_outline.topics,
+            )
+        )
+    lectures.sort(key=lambda lecture: lecture.number)
+
+    return LectureSeries(outline=series_outline, lectures=lectures)
 
 
-def write_lecture_series_to_file(
-    lecture_series_title: str,
-    lectures: list[Lecture],
-    lecture_outline: str,
-    output_dir: Path,
-) -> tuple[Path, Path]:
-    """Writes aggregate lecture text and outline files to disk.
+def write_lecture_series_to_file(lecture_series: LectureSeries, output_dir: Path) -> Path:
+    """Writes the full lecture series, including its outline, to disk.
 
     Args:
-        lecture_series_title: The main title of the lecture series.
-        lectures: A list of Lecture objects.
-        lecture_outline: The full outline text.
+        lecture_series: The complete lecture series, including the outline and all lectures in the series.
         output_dir: The directory where the files will be written.
 
     Returns:
-        A tuple containing:
-          - The path to the aggregate text file.
-          - The path to the outline text file.
+        The path to the lecture series text file.
     """
-    sanitized_title = sanitize_filename(lecture_series_title)
-    aggregate_filename = f"{sanitized_title}.txt"
-    outline_filename = f"{sanitized_title}_outline.txt"
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    aggregate_content = DISCLAIMER + "\n\n"
-    aggregate_content += "\n\n".join(
-        f"Lecture {lecture.number}: {lecture.title}\n\n{lecture.text}" for lecture in lectures
-    )
+    lecture_series_filename = f"{sanitize_filename(lecture_series.outline.title)}.txt"
+    lecture_series_text_path = output_dir / lecture_series_filename
+    lecture_series_text_path.write_text(str(lecture_series), encoding="utf-8")
 
-    aggregate_path = output_dir / aggregate_filename
-    aggregate_path.write_text(aggregate_content, encoding="utf-8")
-
-    outline_path = output_dir / outline_filename
-    outline_path.write_text(lecture_outline, encoding="utf-8")
-
-    return aggregate_path, outline_path
+    return lecture_series_text_path
 
 
 def _download_punkt() -> bool:
@@ -283,7 +278,7 @@ def _split_text_into_chunks(text: str, max_chunk_size: int = 4096) -> list[str]:
     if current_chunk:
         chunks.append(" ".join(current_chunk))
 
-    log.info(f"Split text into {len(chunks)} chunks of ~{max_chunk_size} characters from {len(sentences)}.")
+    log.info(f"Split text into {len(chunks)} chunks of ~{max_chunk_size} characters from {len(sentences)} sentences.")
     return chunks
 
 
@@ -313,40 +308,52 @@ def _generate_audio_chunk(chunk: str, chunk_num: int) -> tuple[int, AudioSegment
         return chunk_num, AudioSegment.from_file(audio_bytes, format="mp3")
 
 
-def generate_audio(lectures: list[Lecture], output_file_path: str) -> None:
-    """Generates an audio file from the combined text of the given list of `Lecture` objects.
-
-    Use ``split_text_into_chunks`` to get a list of `Lecture` objects to pass to this function.
+def generate_audio(lecture_series: LectureSeries, output_file_path: str) -> bool:
+    """Generates an audio file from the combined text of the lectures in the given lecture series.
 
     Args:
-        client: An initialized OpenAI client.
-        lectures: A list of `Lecture` instances.
+        lecture_series: The lecture series containing the lectures for which to generate audio.
         output_file_path: The location to write the audio file.
+
+    Returns:
+        Whether the audio file generation was successful.
     """
-    if _download_punkt():
-        lecture_series_text = DISCLAIMER + "\n\n"
-        lecture_series_text += "\n\n".join(lec.text for lec in lectures)
-        lecture_series_chunks = _split_text_into_chunks(lecture_series_text)
+    if not _download_punkt():
+        # If we don't have NLTK's 'punkt', we can't chunk the text to feed to the LLM for TTS.
+        return False
 
-        audio_chunks = []
-        with ThreadPoolExecutor() as executor:
-            futures = {
-                executor.submit(_generate_audio_chunk, chunk, chunk_num): chunk_num
-                for chunk_num, chunk in enumerate(lecture_series_chunks, start=1)
-            }
+    # Combine all lecture texts, including titles, preceded by the disclosure that it's all AI-generated
+    lecture_series_text = (
+        DISCLAIMER
+        + "\n\n"
+        + "\n\n".join(
+            f"Lecture {lecture.number}, '{lecture.title}'.\n\n{lecture.text}" for lecture in lecture_series.lectures
+        )
+    )
+    lecture_series_chunks = _split_text_into_chunks(lecture_series_text)
 
-            for future in as_completed(futures):
-                chunk_num, lecture_audio_chunk = future.result()
-                audio_chunks.append((chunk_num, lecture_audio_chunk))
+    # Process chunks in parallel to generate audio
+    with ThreadPoolExecutor() as executor:
+        futures = {
+            executor.submit(_generate_audio_chunk, chunk, chunk_num): chunk_num
+            for chunk_num, chunk in enumerate(lecture_series_chunks, start=1)
+        }
 
-        audio_chunks.sort(key=lambda x: x[0])
-        lecture_series_audio = AudioSegment.silent(duration=0)
-        for _, lecture_audio_chunk in audio_chunks:
-            lecture_series_audio += lecture_audio_chunk
+        # Collect results as they complete
+        audio_chunks = sorted(
+            (future.result() for future in as_completed(futures)),
+            key=lambda x: x[0],  # Sort by chunk number
+        )
 
-        # TODO: Support other audio formats.
-        log.info(f"Joining {len(audio_chunks)} audio chunks into one file...")
-        lecture_series_audio.export(output_file_path, format="mp3")
+    # Combine all audio chunks into one audio segment
+    log.info(f"Joining {len(audio_chunks)} audio chunks into one file...")
+    lecture_series_audio = sum(
+        (audio_chunk for _, audio_chunk in audio_chunks),
+        AudioSegment.silent(duration=0),  # Start with silence
+    )
+    lecture_series_audio.export(output_file_path, format="mp3")
+
+    return True
 
 
 def run_generation(topic: str, num_lectures: int, generate_audio_file: bool = False) -> dict:
@@ -359,41 +366,38 @@ def run_generation(topic: str, num_lectures: int, generate_audio_file: bool = Fa
 
     Returns:
         A dictionary containing:
-          "outline_path": Path to the outline text file.
-          "aggregate_path": Path to the aggregate lecture text file.
+          "series_text_path": Path to the lecture series text file.
           "audio_path": Path to the audio file or `None`.
           "total_time": The total elapsed generation time in seconds.
     """
 
     outline_start_time = time.perf_counter()
-    outline_text = generate_lecture_series_outline(topic, num_lectures)
-    lecture_titles = get_lecture_titles_from_outline(outline_text)
+    series_outline = generate_lecture_series_outline(topic, num_lectures)
     outline_end_time = time.perf_counter()
     outline_elapsed = outline_end_time - outline_start_time
 
     series_generation_start_time = time.perf_counter()
-    lectures = get_lectures(lecture_titles, topic, outline_text)
+    lecture_series = get_lectures(series_outline)
     series_generation_end_time = time.perf_counter()
     series_generation_elapsed = series_generation_end_time - series_generation_start_time
 
     output_dir = Path.cwd() / "lectures"
-    aggregate_path, outline_path = write_lecture_series_to_file(topic, lectures, outline_text, output_dir)
+    series_text_path = write_lecture_series_to_file(lecture_series, output_dir)
 
     audio_gen_elapsed = 0.0
-    mp3_path = output_dir / f"{sanitize_filename(topic)}.mp3"
+    mp3_path = output_dir / f"{sanitize_filename(lecture_series.outline.title)}.mp3"
     if generate_audio_file:
         if mp3_path.exists():
             mp3_path.unlink()
         audio_gen_start = time.perf_counter()
-        generate_audio(lectures, str(mp3_path))
+        generate_audio(lecture_series, str(mp3_path))
         audio_gen_end = time.perf_counter()
         audio_gen_elapsed = audio_gen_end - audio_gen_start
 
     total_elapsed = outline_elapsed + series_generation_elapsed + audio_gen_elapsed
 
     return {
-        "outline_path": outline_path,
-        "aggregate_path": aggregate_path,
+        "series_text_path": series_text_path,
         "audio_path": mp3_path if generate_audio_file else None,
         "total_time": total_elapsed,
     }


### PR DESCRIPTION
- Now using Pydantic v2 models for the lecture components
- Using Structured Outputs from OpenAI's API to generate the lecture series outline
- Fixed a bug where lecture titles weren't being included in the text chunks we send to the LLM for TTS
- Cleaned up and simplified a bunch of code
- Added a word-swapper function for removing LLM smell from the lecture text. For example, swapping "delve" with "dig" and "crucial" with "important."