### PR TITLE
lecture prompt and cover art prompt update

### DIFF
--- a/src/okcourse/constants.py
+++ b/src/okcourse/constants.py
@@ -16,12 +16,12 @@ SYSTEM_PROMPT = (
 """System prompt for the lecture outline and lecture text generation requests sent to OpenAI."""
 
 IMAGE_PROMPT = (
-    "Create an image in the style typical of digitial cover art for downloadable audiobooks in MP3 format. The cover "
-    "image should be square and clearly indicate the content of the audiobook to customers browsing the vendor's site. "
+    "Create an image in the style typical of digitial cover art for downloadable podcasts in MP3 format. The cover "
+    "image should clearly indicate the content of the podcast to customers browsing the podcast vendor's site. "
     "The image should be appropriate to accompany the digital distribution of an audio-only recording of the "
     "following college lecture series:\n\n"
 )
-"""Prompt passed to OpenAI's `/image` endpoint. The lecture outline is appended to this prompt before sending the
+"""Prompt passed to OpenAI's `/image` endpoint. The lecture series title is appended to this prompt before sending the
 image generation request."""
 
 LLM_SMELLS = {

--- a/src/okcourse/okcourse.py
+++ b/src/okcourse/okcourse.py
@@ -70,9 +70,11 @@ def get_lecture(series_outline: LectureSeriesOutline, lecture_number: int) -> Le
     if not topic:
         raise ValueError(f"No topic found for lecture number {lecture_number}")
     prompt = (
-        f"Generate the complete unabridged text for a college lecture titled '{topic.title}' in a lecture series on "
+        f"Generate the complete unabridged text for a lecture titled '{topic.title}' in a graduate-level course on "
         "'{series_outline.title}'. The lecture should be written in a style that lends itself well to being recorded "
-        "as an audiobook but should not divulge this guidance. Cover the lecture topic in great detail. "
+        "as an audiobook but should not divulge this guidance. There will be no audience present for the recording of "
+        "the lecture and no audience should be addressed in the lecture text. Cover the lecture topic in great detail "
+        "because you are paid by the minute and the longer the lecture, the more you are paid. "
         "Omit Markdown from the lecture text as well as any tags, formatting markers, or headings that might interfere "
         "with text-to-speech processing. "
         "Ensure the content is original and does not duplicate content from the other lectures in the series.\n"
@@ -192,7 +194,6 @@ def generate_cover_image(lecture_outline: LectureSeriesOutline, image_file_path:
 
     if image_response.data:
         image = image_response.data[0]
-        LOG.info("Got cover image.")
         image_bytes = base64.b64decode(image.b64_json)
         image_file_path.write_bytes(image_bytes)
         return image_file_path
@@ -254,7 +255,7 @@ def generate_audio_for_lectures_in_series(lecture_series: LectureSeries, output_
         cover=str(cover_image_file) if cover_image_file else None,
         tags={
             "title": lecture_series.outline.title,
-            "artist": f"AI: {TEXT_MODEL} & {SPEECH_MODEL}",
+            "artist": f"{TEXT_MODEL} & {SPEECH_MODEL} (AI)",
             "album": "OK Courses",
             "comment": "https://github.com/mmacy/okcourse",
         }


### PR DESCRIPTION
Modifies the lecture text prompt to help reduce "flashiness" and showmanship evident in earlier prompts. Also makes an attempt at getting the model to produce _longer_ lecture text by saying it'll get paid more, but I'm unconvinced it has any such effect.

Modifies the cover art prompt to remove references to an audiobook and instead use "podcast" to help reduce instances of the image model including an actual book in the cover art.