### PR TITLE
write series to JSON file + prompt tweak

### DIFF
--- a/examples/cli_example.py
+++ b/examples/cli_example.py
@@ -1,4 +1,4 @@
-# cli_app.py
+# cli_example.py
 import sys
 
 import questionary
@@ -6,9 +6,9 @@ import questionary
 from okcourse import (
     get_duration_string_from_seconds,
     generate_complete_lecture_series,
-    generate_lecture_series_outline,
-    generate_text_for_lectures_in_series,
-    generate_audio_for_lectures_in_series,
+    # generate_lecture_series_outline,
+    # generate_text_for_lectures_in_series,
+    # generate_audio_for_lectures_in_series,
 )
 
 num_lectures_default = 20

--- a/src/okcourse/constants.py
+++ b/src/okcourse/constants.py
@@ -9,9 +9,11 @@ AI_DISCLAIMER = (
 """Disclaimer required by OpenAI's usage policy."""
 
 SYSTEM_PROMPT = (
-    "You are an esteemed college professor and expert in your field who regularly lectures graduate "
-    "students. You have been asked by a major audiobook publisher to record an audiobook version of a lecture series. "
-    "Your lecture style is professional, direct, and highly technical."
+    "You are an esteemed college professor and expert in your field who typically lectures graduate students. "
+    "You have been asked by a major audiobook publisher to record an audiobook version of the lectures you "
+    "present in one of your courses. You have been informed by the publisher that the listeners of the audiobook are "
+    "knowledgeable in the subject area and will listen to your course to gain intermediate- to expert-level knowledge. "
+    "Your lecture style is professional, direct, and deeply technical."
 )
 """System prompt for the lecture outline and lecture text generation requests sent to OpenAI."""
 
@@ -32,7 +34,9 @@ LLM_SMELLS = {
     "delving": "digging",
     "utilize": "use",
     "utilized": "used",
-    "utilizing": "using"
+    "utilizing": "using",
+    "utilization": "usage",
+    "meticulously": "carefully"
 }
 """Words that tend to be overused by OpenAI's text generation models and their simplified forms.
 

--- a/src/okcourse/okcourse.py
+++ b/src/okcourse/okcourse.py
@@ -74,7 +74,7 @@ def get_lecture(series_outline: LectureSeriesOutline, lecture_number: int) -> Le
         "'{series_outline.title}'. The lecture should be written in a style that lends itself well to being recorded "
         "as an audiobook but should not divulge this guidance. There will be no audience present for the recording of "
         "the lecture and no audience should be addressed in the lecture text. Cover the lecture topic in great detail "
-        "because you are paid by the minute and the longer the lecture, the more you are paid. "
+        "while keeping in mind the advanced education level of the listeners of the lecture. "
         "Omit Markdown from the lecture text as well as any tags, formatting markers, or headings that might interfere "
         "with text-to-speech processing. "
         "Ensure the content is original and does not duplicate content from the other lectures in the series.\n"
@@ -119,32 +119,32 @@ def generate_text_for_lectures_in_series(series_outline: LectureSeriesOutline) -
 
 
 def write_lecture_series_to_file(lecture_series: LectureSeries, output_dir: Path) -> Path:
-    """Writes the full lecture series, including its outline, to disk.
+    """Writes the full lecture series, including its outline, to a JSON file.
 
     Args:
         lecture_series: The complete lecture series, including the outline and all lectures in the series.
         output_dir: The directory where the files will be written.
 
     Returns:
-        The path to the lecture series text file.
+        The path to the lecture series JSON file.
     """
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    lecture_series_filename = f"{sanitize_filename(lecture_series.outline.title)}.txt"
+    lecture_series_filename = f"{sanitize_filename(lecture_series.outline.title)}.json"
     lecture_series_text_path = output_dir / lecture_series_filename
-    lecture_series_text_path.write_text(str(lecture_series), encoding="utf-8")
+    lecture_series_text_path.write_text(lecture_series.model_dump_json(), encoding="utf-8")
 
     return lecture_series_text_path
 
 
-def _generate_tts_audio_for_text_chunk(text_chunk: str, chunk_num: int) -> tuple[int, AudioSegment]:
+def generate_audio_segment_for_text_chunk(text_chunk: str, chunk_num: int = 1) -> tuple[int, AudioSegment]:
     """Generates an MP3 audio segment for a chunk of text using text-to-speech (TTS).
 
     Get text chunks to pass to this function from ``utils.split_text_into_chunks``.
 
     Args:
         chunk: The text chunk to convert to speech.
-        chunk_num: The chunk number.
+        chunk_num: (Optional) The chunk number.
 
     Returns:
         A tuple of (chunk_num, AudioSegment) for the generated audio.
@@ -227,7 +227,7 @@ def generate_audio_for_lectures_in_series(lecture_series: LectureSeries, output_
     # Process chunks in parallel to generate audio
     with ThreadPoolExecutor() as executor:
         futures = {
-            executor.submit(_generate_tts_audio_for_text_chunk, chunk, chunk_num): chunk_num
+            executor.submit(generate_audio_segment_for_text_chunk, chunk, chunk_num): chunk_num
             for chunk_num, chunk in enumerate(lecture_series_chunks, start=1)
         }
 


### PR DESCRIPTION
- Write LectureSeries to JSON instead of TXT to enable easy load+parse back into LectureSeries if needed
- Tweak the `system` prompt and lecture request `user` prompt to help avoid every lecture series starting with a lecture introducing the subject of the series as if it were completely new to the audience. For example, if I ask for a lecture series on the history of apple production in Washington State, I don't need the first lecture in the series to be devoted to introducing me to apples - I know what an apple is.
  - This might be a preference thing, however, and depending on the subject, you might actually want to be introduced from the ground up. This should probably be made a setting once I get to adding the settings facility.