### PR TITLE
Lecture text and covert art prompt fixes

### DIFF
--- a/examples/cli_example.py
+++ b/examples/cli_example.py
@@ -47,7 +47,7 @@ def main():
 
     do_generate_cover_art = False
     if do_generate_audio:
-        if questionary.confirm("Generate image for audio file album art").ask():
+        if questionary.confirm("Generate image for audio file album art?").ask():
             do_generate_cover_art = True
 
     print("Generating lecture series...")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "okcourse"
-version = "0.1.1"
+version = "0.1.2"
 description = "Generate audiobook-style courses in MP3 format with lectures on any topic using Python and the OpenAI API."
 readme = "README.md"
 authors = [

--- a/src/okcourse/constants.py
+++ b/src/okcourse/constants.py
@@ -20,10 +20,11 @@ SYSTEM_PROMPT = (
 """System prompt for the lecture outline and lecture text generation requests sent to OpenAI."""
 
 IMAGE_PROMPT = (
-    "Create an image in the style typical of digitial cover art for downloadable podcasts in MP3 format. The cover "
-    "image should clearly indicate the content of the podcast to customers browsing the podcast vendor's site. "
-    "The image should be appropriate to accompany the digital distribution of an audio-only recording of the "
-    "following college lecture series:\n\n"
+    "Create an image in the style of cover art for an audio recording of a college lecture series shown in an online "
+    "academic catalog. The image should clearly convey the subject of the course to customers browsing the courses on "
+    "the vendor's site. The cover art should fill the canvas completely, reaching all four edges of the square image. "
+    "Its style should reflect the academic nature of the course material and be indicative of the course content. "
+    "The title of the course is:\n\n"
 )
 """Prompt passed to OpenAI's `/image` endpoint. The lecture series title is appended to this prompt before sending the
 image generation request."""


### PR DESCRIPTION
- Improves prompt to generate MP3 cover art so it fills the square and has less chance of looking like a book cover. Again. Hopefully.
- Fixes lecture text prompt to pass the actual lecture series outline.
- MP3 `artist` tag now includes the image model along with the text and TTS models if cover art was generated.