### PR TITLE
API ref doc generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,56 @@
 # okcourse
 
-<!-- ---8<--- [start:get-started] -->
+The `okcourse` module generates audio lectures in MP3 format for any topic using Python and the OpenAI API. You supply a topic for the course, the number of lectures in the series, and the LLM generates the series outline, lecture text, and audio for the entire series.
 
-The `okcourse` Python library generates content and audio for lectures on any topic.(1) You specify the course title and number of lectures and OpenAI's models generate the course outline, lecture text, cover image, and audio file.
-{ .annotate }
+A real README will replace this one (for realsies), but for now, here's output from a run of the CLI example app generating a four-lecture "course" with logging enabled:
 
-1. Any topic that doesn't run afoul of [OpenAI's usage policy](https://openai.com/policies/usage-policies/).
-
-## Prerequisites
-
-- [Python](https://www.python.org/) 3.12+
-- [ffmpeg](https://www.ffmpeg.org/)
-- [OpenAI API key](https://platform.openai.com/account/api-keys)
-
-## Install
-
-The `okcourse` package is not yet on PyPi due to its rapidly changing API surface.
-
-Until the API surface solidifies, you can install it directly from GitHub:
-
-```sh
-# TODO: pip install git+blahblah
+```console
+$ uv run examples/cli_example.py
+===================
+==  Courserator  ==
+===================
+? Enter a lecture series topic: Neutron star formation in depth
+? How many lectures should be in the series (default: 20)? 4
+? Generate MP3 audio file for lecture series? Yes
+Generating lecture series...
+2024-12-12 22:28:47 [INFO] Requesting lecture series outline from LLM...
+2024-12-12 22:28:52 [INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK"
+2024-12-12 22:28:52 [INFO] Resetting lecture series topic to 'Neutron star formation in depth' from LLM-provided 'Neutron Star Formation in Depth'
+2024-12-12 22:28:52 [INFO] Requesting lecture text from LLM for topic 1/4: Stellar Evolution and Supernova Mechanisms...
+2024-12-12 22:28:52 [INFO] Requesting lecture text from LLM for topic 2/4: Degenerate Matter and Neutronization...
+2024-12-12 22:28:52 [INFO] Requesting lecture text from LLM for topic 3/4: Structure and Properties of Neutron Stars...
+2024-12-12 22:28:52 [INFO] Requesting lecture text from LLM for topic 4/4: Binary Systems and Neutron Star Mergers...
+2024-12-12 22:28:58 [INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK"
+2024-12-12 22:28:58 [INFO] Got lexture text from LLM for 'Degenerate Matter and Neutronization'...
+2024-12-12 22:29:01 [INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK"
+2024-12-12 22:29:01 [INFO] Got lexture text from LLM for 'Structure and Properties of Neutron Stars'...
+2024-12-12 22:29:05 [INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK"
+2024-12-12 22:29:05 [INFO] Got lexture text from LLM for 'Stellar Evolution and Supernova Mechanisms'...
+2024-12-12 22:29:09 [INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK"
+2024-12-12 22:29:09 [INFO] Got lexture text from LLM for 'Binary Systems and Neutron Star Mergers'...
+2024-12-12 22:29:09 [INFO] Checking for NLTK 'punkt' tokenizer...
+2024-12-12 22:29:09 [INFO] Found NLTK 'punkt' tokenizer.
+2024-12-12 22:29:09 [INFO] Split text into 5 chunks of ~4096 characters from 121 sentences.
+2024-12-12 22:29:09 [INFO] Requesting TTS-generated audio for text chunk 1...
+2024-12-12 22:29:09 [INFO] Requesting TTS-generated audio for text chunk 2...
+2024-12-12 22:29:09 [INFO] Requesting TTS-generated audio for text chunk 3...
+2024-12-12 22:29:09 [INFO] Requesting TTS-generated audio for text chunk 4...
+2024-12-12 22:29:09 [INFO] Requesting TTS-generated audio for text chunk 5...
+2024-12-12 22:29:10 [INFO] HTTP Request: POST https://api.openai.com/v1/audio/speech "HTTP/1.1 200 OK"
+2024-12-12 22:29:10 [INFO] HTTP Request: POST https://api.openai.com/v1/audio/speech "HTTP/1.1 200 OK"
+2024-12-12 22:29:11 [INFO] HTTP Request: POST https://api.openai.com/v1/audio/speech "HTTP/1.1 200 OK"
+2024-12-12 22:29:11 [INFO] HTTP Request: POST https://api.openai.com/v1/audio/speech "HTTP/1.1 200 OK"
+2024-12-12 22:29:11 [INFO] HTTP Request: POST https://api.openai.com/v1/audio/speech "HTTP/1.1 200 OK"
+2024-12-12 22:29:21 [INFO] Got TTS-generated audio for text chunk 5.
+2024-12-12 22:29:37 [INFO] Got TTS-generated audio for text chunk 2.
+2024-12-12 22:29:40 [INFO] Got TTS-generated audio for text chunk 1.
+2024-12-12 22:29:46 [INFO] Got TTS-generated audio for text chunk 4.
+2024-12-12 22:29:50 [INFO] Got TTS-generated audio for text chunk 3.
+2024-12-12 22:29:50 [INFO] Joining 5 audio chunks into one file...
+Lecture series generation complete.
+Lecture series text: /Users/mmacy/repos/okcourse/lectures/neutron_star_formation_in_depth.txt
+Lecture series audio: /Users/mmacy/repos/okcourse/lectures/neutron_star_formation_in_depth.mp3
+Total generation time: 1:06
 ```
 
-## Try an example
-
-TODO
+The duration of the MP3 generated by this example run was **17m38s** and the file size was **~4 MB**.

--- a/README.md
+++ b/README.md
@@ -1,56 +1,28 @@
 # okcourse
 
-The `okcourse` module generates audio lectures in MP3 format for any topic using Python and the OpenAI API. You supply a topic for the course, the number of lectures in the series, and the LLM generates the series outline, lecture text, and audio for the entire series.
+<!-- ---8<--- [start:get-started] -->
 
-A real README will replace this one (for realsies), but for now, here's output from a run of the CLI example app generating a four-lecture "course" with logging enabled:
+The `okcourse` Python library generates content and audio for lectures on any topic.(1) You specify the course title and number of lectures and OpenAI's models generate the course outline, lecture text, cover image, and audio file.
+{ .annotate }
 
-```console
-$ uv run examples/cli_example.py
-===================
-==  Courserator  ==
-===================
-? Enter a lecture series topic: Neutron star formation in depth
-? How many lectures should be in the series (default: 20)? 4
-? Generate MP3 audio file for lecture series? Yes
-Generating lecture series...
-2024-12-12 22:28:47 [INFO] Requesting lecture series outline from LLM...
-2024-12-12 22:28:52 [INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK"
-2024-12-12 22:28:52 [INFO] Resetting lecture series topic to 'Neutron star formation in depth' from LLM-provided 'Neutron Star Formation in Depth'
-2024-12-12 22:28:52 [INFO] Requesting lecture text from LLM for topic 1/4: Stellar Evolution and Supernova Mechanisms...
-2024-12-12 22:28:52 [INFO] Requesting lecture text from LLM for topic 2/4: Degenerate Matter and Neutronization...
-2024-12-12 22:28:52 [INFO] Requesting lecture text from LLM for topic 3/4: Structure and Properties of Neutron Stars...
-2024-12-12 22:28:52 [INFO] Requesting lecture text from LLM for topic 4/4: Binary Systems and Neutron Star Mergers...
-2024-12-12 22:28:58 [INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK"
-2024-12-12 22:28:58 [INFO] Got lexture text from LLM for 'Degenerate Matter and Neutronization'...
-2024-12-12 22:29:01 [INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK"
-2024-12-12 22:29:01 [INFO] Got lexture text from LLM for 'Structure and Properties of Neutron Stars'...
-2024-12-12 22:29:05 [INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK"
-2024-12-12 22:29:05 [INFO] Got lexture text from LLM for 'Stellar Evolution and Supernova Mechanisms'...
-2024-12-12 22:29:09 [INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK"
-2024-12-12 22:29:09 [INFO] Got lexture text from LLM for 'Binary Systems and Neutron Star Mergers'...
-2024-12-12 22:29:09 [INFO] Checking for NLTK 'punkt' tokenizer...
-2024-12-12 22:29:09 [INFO] Found NLTK 'punkt' tokenizer.
-2024-12-12 22:29:09 [INFO] Split text into 5 chunks of ~4096 characters from 121 sentences.
-2024-12-12 22:29:09 [INFO] Requesting TTS-generated audio for text chunk 1...
-2024-12-12 22:29:09 [INFO] Requesting TTS-generated audio for text chunk 2...
-2024-12-12 22:29:09 [INFO] Requesting TTS-generated audio for text chunk 3...
-2024-12-12 22:29:09 [INFO] Requesting TTS-generated audio for text chunk 4...
-2024-12-12 22:29:09 [INFO] Requesting TTS-generated audio for text chunk 5...
-2024-12-12 22:29:10 [INFO] HTTP Request: POST https://api.openai.com/v1/audio/speech "HTTP/1.1 200 OK"
-2024-12-12 22:29:10 [INFO] HTTP Request: POST https://api.openai.com/v1/audio/speech "HTTP/1.1 200 OK"
-2024-12-12 22:29:11 [INFO] HTTP Request: POST https://api.openai.com/v1/audio/speech "HTTP/1.1 200 OK"
-2024-12-12 22:29:11 [INFO] HTTP Request: POST https://api.openai.com/v1/audio/speech "HTTP/1.1 200 OK"
-2024-12-12 22:29:11 [INFO] HTTP Request: POST https://api.openai.com/v1/audio/speech "HTTP/1.1 200 OK"
-2024-12-12 22:29:21 [INFO] Got TTS-generated audio for text chunk 5.
-2024-12-12 22:29:37 [INFO] Got TTS-generated audio for text chunk 2.
-2024-12-12 22:29:40 [INFO] Got TTS-generated audio for text chunk 1.
-2024-12-12 22:29:46 [INFO] Got TTS-generated audio for text chunk 4.
-2024-12-12 22:29:50 [INFO] Got TTS-generated audio for text chunk 3.
-2024-12-12 22:29:50 [INFO] Joining 5 audio chunks into one file...
-Lecture series generation complete.
-Lecture series text: /Users/mmacy/repos/okcourse/lectures/neutron_star_formation_in_depth.txt
-Lecture series audio: /Users/mmacy/repos/okcourse/lectures/neutron_star_formation_in_depth.mp3
-Total generation time: 1:06
+1. Any topic that doesn't run afoul of [OpenAI's usage policy](https://openai.com/policies/usage-policies/).
+
+## Prerequisites
+
+- [Python](https://www.python.org/) 3.12+
+- [ffmpeg](https://www.ffmpeg.org/)
+- [OpenAI API key](https://platform.openai.com/account/api-keys)
+
+## Install
+
+The `okcourse` package is not yet on PyPi due to its rapidly changing API surface.
+
+Until the API surface solidifies, you can install it directly from GitHub:
+
+```sh
+# TODO: pip install git+blahblah
 ```
 
-The duration of the MP3 generated by this example run was **17m38s** and the file size was **~4 MB**.
+## Try an example
+
+TODO

--- a/docs/examples/cli.md
+++ b/docs/examples/cli.md
@@ -1,0 +1,3 @@
+# CLI example
+
+TODO: Ingest cli_example.py

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,0 +1,1 @@
+# Examples

--- a/docs/examples/streamlit.md
+++ b/docs/examples/streamlit.md
@@ -1,0 +1,3 @@
+# Streamlit example
+
+TODO: Ingest ST example

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -1,0 +1,3 @@
+# Get started
+
+--8<-- "./README.md:get-started"

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,29 +1,20 @@
 # Welcome
 
-Welcome to the documentation for the `okcourse` Python library.
-
 <div class="grid cards" markdown>
-- :material-clock-fast: [Get started](./get_started.md)
+- :material-clock-fast: [Get started](./get-started.md)
 - :simple-python: [API reference](reference/index.md)
 - :octicons-file-code-16: [Example code](./examples/index.md)
 <!-- - :octicons-versions-16: [Library `CHANGELOG`](./changelog.md) -->
 </div>
 
-## Generate OK course lectures with AI
+## Inspirations
 
-TODO: Intro goes here.
-
-## Related projects
-
-The following were inspirations for this project:
+The following were all inspirations for the `okcourse` library:
 
 - [podgenai](https://github.com/impredicative/podgenai)
 - [tts-joinery](https://github.com/drien/tts-joinery)
-- [Great Courses](https://www.thegreatcourses.com/) by The Teaching Company (1)
-{ .annotate }
+- [The Great Courses](https://www.thegreatcourses.com/)
 
 Check 'em out!
-
-1. Unlike lectures in AI-generated courses, the human-generated [Great Courses](https://www.thegreatcourses.com/) lectures *are* actually great. If you haven't already, I highly recommend checking them out.
 
 :material-peace: *Enjoy!* —[Marsh](https://github.com/mmacy)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1 +1,29 @@
-# okcourse
+# Welcome
+
+Welcome to the documentation for the `okcourse` Python library.
+
+<div class="grid cards" markdown>
+- :material-clock-fast: [Get started](./get_started.md)
+- :simple-python: [API reference](reference/index.md)
+- :octicons-file-code-16: [Example code](./examples/index.md)
+<!-- - :octicons-versions-16: [Library `CHANGELOG`](./changelog.md) -->
+</div>
+
+## Generate OK course lectures with AI
+
+TODO: Intro goes here.
+
+## Related projects
+
+The following were inspirations for this project:
+
+- [podgenai](https://github.com/impredicative/podgenai)
+- [tts-joinery](https://github.com/drien/tts-joinery)
+- [Great Courses](https://www.thegreatcourses.com/) by The Teaching Company (1)
+{ .annotate }
+
+Check 'em out!
+
+1. Unlike lectures in AI-generated courses, the human-generated [Great Courses](https://www.thegreatcourses.com/) lectures *are* actually great. If you haven't already, I highly recommend checking them out.
+
+:material-peace: *Enjoy!* —[Marsh](https://github.com/mmacy)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,5 @@
+# okcourse
+
+::: okcourse
+    options:
+          docstring_section_style: spacy

--- a/examples/cli_example.py
+++ b/examples/cli_example.py
@@ -21,10 +21,10 @@ from okcourse import (
     generate_course_lectures,
     generate_course_outline,
     sanitize_filename,
-    configure_logging,
+    enable_logging,
 )
 
-configure_logging(logging.INFO)
+enable_logging(logging.INFO)
 
 num_lectures_default = 10
 # 20 lectures yields approx. 1:40:00 MP3

--- a/examples/cli_example_async.py
+++ b/examples/cli_example_async.py
@@ -18,7 +18,7 @@ import questionary
 
 from okcourse import (
     TTS_VOICES,
-    configure_logging,
+    enable_logging,
     generate_course_audio_async,
     generate_course_image_async,
     generate_course_lectures_async,
@@ -26,7 +26,7 @@ from okcourse import (
     sanitize_filename,
 )
 
-configure_logging(logging.INFO)
+enable_logging(logging.INFO)
 
 num_lectures_default = 10
 # 20 lectures yields approx. 1:40:00 MP3

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,7 +82,8 @@ plugins:
         load_external_modules: false # 'true' picks up __all__ from __init__.py files
         import:
           - https://docs.python.org/3/objects.inv
-          - https://docs.pydantic.dev/2.4/objects.inv
+          - https://docs.pydantic.dev/2.10/objects.inv
+          - https://mmacy.github.io/openai-python/latest/objects.inv
         options:
           docstring_options:
             ignore_init_summary: true
@@ -115,17 +116,7 @@ nav:
   - Welcome:
     - index.md
     - Get started: get-started.md
+    - Examples: examples/index.md
     - API reference: reference/index.md
-  #  - Examples: examples/index.md
-  #   - Changelog: changelog.md
-  # - Get started:
-  #     - get_started.md
-  #     - connect.md
-  #     - request-response.md
-  #     - error-handling.md
-  #     - debugging.md
-  #     - advanced.md
-  #     - helpers.md
+  - Examples: examples/
   - API reference: reference/
-#  - Example code: examples/
-#  - Changelog: changelog.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,11 +1,131 @@
 site_name: OK Courses
-site_url: https://mmacy.github.io/okcourse
+site_author: Marsh Macy
+site_description: A library that generates courses containing lectures on any topic by using AI. They're not great, but they're OK.
+site_url: https://mmacy.github.io/okcourse/
+repo_name: okcourse
+repo_url: https://github.com/mmacy/okcourse
+watch: [README.md, src/okcourse]
+
 theme:
   name: material
+  icon:
+    repo: fontawesome/brands/git-alt
+
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: grey
+      accent: orange
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: grey
+      accent: orange
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+  font:
+    text: Inter
+    code: Chivo Mono
+
+  features:
+    - content.code.annotate
+    - header.autohide
+    - search.share
+    - search.suggest
+    - toc.follow
+
+    - navigation.footer
+    - navigation.indexes
+    - navigation.instant
+    - navigation.instant.progress
+    - navigation.prune
+    - navigation.sections
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.top
+    - navigation.tracking
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.tasklist:
+      custom_checkbox: true
 
 plugins:
 - search
+- gen-files:
+      scripts:
+        - scripts/gen_ref_docs.py
+- literate-nav:
+    nav_file: SUMMARY.md
+
 - mkdocstrings:
     handlers:
       python:
         paths: [src]
+        load_external_modules: false # 'true' picks up __all__ from __init__.py files
+        import:
+          - https://docs.python.org/3/objects.inv
+          - https://docs.pydantic.dev/2.4/objects.inv
+        options:
+          docstring_options:
+            ignore_init_summary: true
+            summary: true
+          docstring_section_style: table
+          docstring_style: google
+          filters: ["!^_"]
+          heading_level: 3
+          inherited_members: false
+          merge_init_into_class: true
+          separate_signature: true
+          show_bases: false
+          show_if_no_docstring: true
+          show_root_full_path: false
+          show_root_heading: false
+          show_signature_annotations: true
+          show_source: false
+          show_symbol_type_heading: true
+          show_symbol_type_toc: true
+          signature_crossrefs: true
+          summary: true
+          unwrap_annotated: true
+
+extra:
+  social:
+  - icon: fontawesome/brands/github
+    link: https://github.com/mmacy
+
+nav:
+  - Welcome:
+    - index.md
+    - Get started: get-started.md
+    - API reference: reference/index.md
+  #  - Examples: examples/index.md
+  #   - Changelog: changelog.md
+  # - Get started:
+  #     - get_started.md
+  #     - connect.md
+  #     - request-response.md
+  #     - error-handling.md
+  #     - debugging.md
+  #     - advanced.md
+  #     - helpers.md
+  - API reference: reference/
+#  - Example code: examples/
+#  - Changelog: changelog.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ dev = [
     "streamlit>=1.41.0",
 ]
 docs = [
+    "black>=24.10.0",
+    "mkdocs-gen-files>=0.5.0",
     "mkdocs-literate-nav>=0.6.1",
     "mkdocs-material>=9.5.49",
     "mkdocstrings-python>=1.12.2",

--- a/scripts/gen_ref_docs.py
+++ b/scripts/gen_ref_docs.py
@@ -1,0 +1,42 @@
+"""Generates reference docs from the docstrings in the code.
+
+Adapted from https://github.com/mkdocstrings/mkdocstrings/blob/2f6ddb/scripts/gen_ref_nav.py
+"""
+
+from pathlib import Path
+
+import mkdocs_gen_files
+
+nav = mkdocs_gen_files.Nav()
+
+src = Path(__file__).parent / "src"
+
+for path in sorted(src.rglob("*.py")):
+    module_path = path.relative_to(src).with_suffix("")
+    doc_path = path.relative_to(src / "okcourse").with_suffix(".md")
+    full_doc_path = Path("reference", doc_path)
+
+    parts = tuple(module_path.parts)
+
+    if parts[-1] == "__init__":
+        parts = parts[:-1]
+        doc_path = doc_path.with_name("index.md")
+        full_doc_path = full_doc_path.with_name("index.md")
+    elif parts[-1].startswith("_"):
+        continue
+
+    nav_parts = [part for part in parts]
+    nav[tuple(nav_parts)] = doc_path.as_posix()
+
+    # with mkdocs_gen_files.open(full_doc_path, "w") as fd:
+    #     ident = ".".join(parts)
+    #     fd.write(f"::: src.{ident}")
+
+    with mkdocs_gen_files.open(full_doc_path, "w") as fd:
+        ident = ".".join(parts)
+        fd.write(f"---\ntitle: {ident}\n---\n\n::: {ident}")
+
+    mkdocs_gen_files.set_edit_path(full_doc_path, ".." / path)
+
+with mkdocs_gen_files.open("reference/SUMMARY.md", "w") as nav_file:
+    nav_file.writelines(nav.build_literate_nav())

--- a/scripts/gen_ref_docs.py
+++ b/scripts/gen_ref_docs.py
@@ -1,15 +1,14 @@
-"""Generates reference docs from the docstrings in the code.
-
-Adapted from https://github.com/mkdocstrings/mkdocstrings/blob/2f6ddb/scripts/gen_ref_nav.py
-"""
+"""Generate the code reference pages and navigation."""
 
 from pathlib import Path
 
 import mkdocs_gen_files
 
 nav = mkdocs_gen_files.Nav()
+mod_symbol = '<code class="doc-symbol doc-symbol-nav doc-symbol-module"></code>'
 
-src = Path(__file__).parent / "src"
+root = Path(__file__).parent.parent
+src = root / "src"
 
 for path in sorted(src.rglob("*.py")):
     module_path = path.relative_to(src).with_suffix("")
@@ -25,18 +24,14 @@ for path in sorted(src.rglob("*.py")):
     elif parts[-1].startswith("_"):
         continue
 
-    nav_parts = [part for part in parts]
+    nav_parts = [f"{mod_symbol} {part}" for part in parts]
     nav[tuple(nav_parts)] = doc_path.as_posix()
-
-    # with mkdocs_gen_files.open(full_doc_path, "w") as fd:
-    #     ident = ".".join(parts)
-    #     fd.write(f"::: src.{ident}")
 
     with mkdocs_gen_files.open(full_doc_path, "w") as fd:
         ident = ".".join(parts)
         fd.write(f"---\ntitle: {ident}\n---\n\n::: {ident}")
 
-    mkdocs_gen_files.set_edit_path(full_doc_path, ".." / path)
+    mkdocs_gen_files.set_edit_path(full_doc_path, ".." / path.relative_to(root))
 
 with mkdocs_gen_files.open("reference/SUMMARY.md", "w") as nav_file:
     nav_file.writelines(nav.build_literate_nav())

--- a/src/okcourse/__init__.py
+++ b/src/okcourse/__init__.py
@@ -13,7 +13,7 @@ from .okcourse import (
     generate_course_outline,
     generate_course_outline_async,
 )
-from .utils import configure_logging, get_duration_string_from_seconds, sanitize_filename
+from .utils import enable_logging, get_duration_string_from_seconds, sanitize_filename
 
 __all__ = [
     "Course",
@@ -31,7 +31,7 @@ __all__ = [
     "generate_course_outline_async",
     "generate_course_outline",
     "generate_course",
-    "configure_logging",
+    "enable_logging",
     "get_duration_string_from_seconds",
     "sanitize_filename",
 ]

--- a/src/okcourse/constants.py
+++ b/src/okcourse/constants.py
@@ -1,4 +1,4 @@
-"""Globally accessible configuration and library default values."""
+"""Globally accessible configuration and library defaults."""
 
 TEXT_MODEL = "gpt-4o"
 """Name of the AI model to use for generating the course outline and lecture text."""
@@ -8,20 +8,28 @@ TTS_MODEL = "tts-1"
 
 TTS_VOICES = ["alloy", "echo", "fable", "onyx", "nova", "shimmer"]
 """List of voices available for the text-to-speech model. Determines the voice of the lecturer in the course audio file.
+
 Voice samples are available on
-[platform.openai.com/.../text-to-speech](https://platform.openai.com/docs/guides/text-to-speech)."""
+[platform.openai.com/.../text-to-speech](https://platform.openai.com/docs/guides/text-to-speech).
+"""
 
 IMAGE_MODEL = "dall-e-3"
 """Name of the AI model to use for generating the cover image for the course audio file."""
 
 MAX_LECTURES = 100
-"""Maximum number of lectures that may be generated for a course. This limit is imposed to help avoid accidental
-excessive API usage and its associated cost rather than being a technical limitation."""
+"""Maximum number of lectures that may be generated for a course.
+
+This limit is imposed to help avoid accidental excessive API usage and its associated cost rather than being a technical
+limitation.
+"""
 
 AI_DISCLAIMER = (
     "This is an AI-generated voice, not a human, presenting AI-generated content that might be biased or inaccurate."
 )
-"""Disclaimer required by OpenAI's usage policy."""
+"""Disclaimer required by the [OpenAI usage policy](https://openai.com/policies/usage-policies/).
+
+This disclaimer is inserted as the first line in the course audio.
+"""
 
 SYSTEM_PROMPT = (
     "You are an esteemed college professor and expert in your field who typically lectures graduate students. "
@@ -40,11 +48,13 @@ IMAGE_PROMPT = (
     "The title of the course is:\n\n"
 )
 """The prompt sent to the [`IMAGE_MODEL`][okcourse.constants.IMAGE_MODEL] when requesting a cover image for the course.
-The user-specified course title is appended to this prompt before sending the request to the OpenAI API with
-[`Completions.create()`][src.openai.resources.Completions.create]."""
 
-LLM_SMELLS = {
-    "crucial": "important",
+The user-specified course title is appended to this prompt before sending the request to the OpenAI API with
+[`Completions.create()`][src.openai.resources.Completions.create].
+"""
+
+LLM_SMELLS = {  # TODO: Add support for phrases like "such as" (like) and "in order to" (to).
+    # "crucial": "important",  # TODO: Uncomment when we can handle phrases (breaks right now due to a/an mismatch).
     "delve": "dig",
     "delved": "dug",
     "delves": "digs",
@@ -56,6 +66,7 @@ LLM_SMELLS = {
     "meticulous": "careful",
     "meticulously": "carefully",
 }
-"""Words that tend to be overused by OpenAI's text generation models and their simplified forms.
+"""Dictionary with key/value pairs of words overused by OpenAI's language models and their simplified forms.
 
-By default, overused keys are replaced by their simplified values in lecture text to help reduce \"LLM smell.\""""
+Words in the keys are replaced by their simplified forms in generated lecture text to help reduce \"LLM smell.\"
+"""

--- a/src/okcourse/constants.py
+++ b/src/okcourse/constants.py
@@ -1,11 +1,22 @@
-"""Global defaults."""
+"""Globally accessible configuration and library default values."""
 
 TEXT_MODEL = "gpt-4o"
-SPEECH_MODEL = "tts-1"
+"""Name of the AI model to use for generating the course outline and lecture text."""
+
+TTS_MODEL = "tts-1"
+"""Name of the AI model to use for generating the course audio file."""
+
 TTS_VOICES = ["alloy", "echo", "fable", "onyx", "nova", "shimmer"]
+"""List of voices available for the text-to-speech model. Determines the voice of the lecturer in the course audio file.
+Voice samples are available on
+[platform.openai.com/.../text-to-speech](https://platform.openai.com/docs/guides/text-to-speech)."""
+
 IMAGE_MODEL = "dall-e-3"
+"""Name of the AI model to use for generating the cover image for the course audio file."""
+
 MAX_LECTURES = 100
-MAX_CONCURRENT_TASKS = 32
+"""Maximum number of lectures that may be generated for a course. This limit is imposed to help avoid accidental
+excessive API usage and its associated cost rather than being a technical limitation."""
 
 AI_DISCLAIMER = (
     "This is an AI-generated voice, not a human, presenting AI-generated content that might be biased or inaccurate."
@@ -28,8 +39,9 @@ IMAGE_PROMPT = (
     "Its style should reflect the academic nature of the course material and be indicative of the course content. "
     "The title of the course is:\n\n"
 )
-"""Prompt passed to OpenAI's `/image` endpoint. The course title is appended to this prompt before sending the
-image generation request."""
+"""The prompt sent to the [`IMAGE_MODEL`][okcourse.constants.IMAGE_MODEL] when requesting a cover image for the course.
+The user-specified course title is appended to this prompt before sending the request to the OpenAI API with
+[`Completions.create()`][src.openai.resources.Completions.create]."""
 
 LLM_SMELLS = {
     "crucial": "important",

--- a/src/okcourse/models.py
+++ b/src/okcourse/models.py
@@ -1,3 +1,5 @@
+"""Pydantic model classes representing a course and its components like the outline, lecture topics, and lectures."""
+
 from pydantic import BaseModel, Field
 
 

--- a/src/okcourse/okcourse.py
+++ b/src/okcourse/okcourse.py
@@ -16,7 +16,7 @@ from .constants import (
     IMAGE_MODEL,
     IMAGE_PROMPT,
     LLM_SMELLS,
-    SPEECH_MODEL,
+    TTS_MODEL,
     SYSTEM_PROMPT,
     TEXT_MODEL,
     MAX_LECTURES,
@@ -76,8 +76,8 @@ async def generate_lecture_async(course_outline: CourseOutline, lecture_number: 
     """Generates a lecture for the topic with the specified number in the given outline.
 
     Args:
-        outline: The outline of the course containing lecture topics and their subtopics.
-        number: The position number of the lecture to generate.
+        course_outline: The outline of the course containing lecture topics and their subtopics.
+        lecture_number: The position number of the lecture to generate.
 
     Returns:
         A Lecture object representing the lecture for the given number.
@@ -149,7 +149,8 @@ async def generate_speech_for_text_chunk_async(
     Get text chunks to pass to this function from ``utils.split_text_into_chunks``.
 
     Args:
-        chunk: The text chunk to convert to speech.
+        text_chunk: The text chunk to convert to speech.
+        voice: (Optional) The name of the voice to use for the TTS.
         chunk_num: (Optional) The chunk number.
 
     Returns:
@@ -158,7 +159,7 @@ async def generate_speech_for_text_chunk_async(
     log.info(f"Requesting TTS audio in voice '{voice}' for text chunk {chunk_num}...")
     async with client.audio.speech.with_streaming_response.create(
         # TODO: Allow runtime specification of the model (and later, the service).
-        model=SPEECH_MODEL,
+        model=TTS_MODEL,
         voice=voice,
         input=text_chunk,
     ) as response:
@@ -259,10 +260,10 @@ async def generate_course_audio_async(
     )
 
     if cover_image_path:
-        composer_tag = f"{TEXT_MODEL} & {SPEECH_MODEL} & {IMAGE_MODEL}"
+        composer_tag = f"{TEXT_MODEL} & {TTS_MODEL} & {IMAGE_MODEL}"
         cover_tag = str(cover_image_path)
     else:
-        composer_tag = f"{TEXT_MODEL} & {SPEECH_MODEL}"
+        composer_tag = f"{TEXT_MODEL} & {TTS_MODEL}"
 
     output_dir = output_file_path.parent
     if not output_dir.exists():

--- a/src/okcourse/okcourse.py
+++ b/src/okcourse/okcourse.py
@@ -1,3 +1,5 @@
+"""Main module for the okcourse package. Primary interface for generating course outlines, lectures, and audio files."""
+
 import asyncio
 import base64
 import io

--- a/src/okcourse/utils.py
+++ b/src/okcourse/utils.py
@@ -1,3 +1,5 @@
+"""Utility functions that support operations performed by other modules in the okcourse library."""
+
 import os
 import logging
 from datetime import timedelta
@@ -9,7 +11,7 @@ import re
 log = logging.getLogger(__name__)
 
 
-def configure_logging(level: int | None = None):
+def enable_logging(level: int | None = None):
     """Configure logging for the okcourse library.
 
     Args:

--- a/uv.lock
+++ b/uv.lock
@@ -68,6 +68,30 @@ wheels = [
 ]
 
 [[package]]
+name = "black"
+version = "24.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "mypy-extensions" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/0d/cc2fb42b8c50d80143221515dd7e4766995bd07c56c9a3ed30baf080b6dc/black-24.10.0.tar.gz", hash = "sha256:846ea64c97afe3bc677b761787993be4991810ecc7a4a937816dd6bddedc4875", size = 645813 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/04/bf74c71f592bcd761610bbf67e23e6a3cff824780761f536512437f1e655/black-24.10.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e39e0fae001df40f95bd8cc36b9165c5e2ea88900167bddf258bacef9bbdc3", size = 1644256 },
+    { url = "https://files.pythonhosted.org/packages/4c/ea/a77bab4cf1887f4b2e0bce5516ea0b3ff7d04ba96af21d65024629afedb6/black-24.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d37d422772111794b26757c5b55a3eade028aa3fde43121ab7b673d050949d65", size = 1448534 },
+    { url = "https://files.pythonhosted.org/packages/4e/3e/443ef8bc1fbda78e61f79157f303893f3fddf19ca3c8989b163eb3469a12/black-24.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14b3502784f09ce2443830e3133dacf2c0110d45191ed470ecb04d0f5f6fcb0f", size = 1761892 },
+    { url = "https://files.pythonhosted.org/packages/52/93/eac95ff229049a6901bc84fec6908a5124b8a0b7c26ea766b3b8a5debd22/black-24.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:30d2c30dc5139211dda799758559d1b049f7f14c580c409d6ad925b74a4208a8", size = 1434796 },
+    { url = "https://files.pythonhosted.org/packages/d0/a0/a993f58d4ecfba035e61fca4e9f64a2ecae838fc9f33ab798c62173ed75c/black-24.10.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cbacacb19e922a1d75ef2b6ccaefcd6e93a2c05ede32f06a21386a04cedb981", size = 1643986 },
+    { url = "https://files.pythonhosted.org/packages/37/d5/602d0ef5dfcace3fb4f79c436762f130abd9ee8d950fa2abdbf8bbc555e0/black-24.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f93102e0c5bb3907451063e08b9876dbeac810e7da5a8bfb7aeb5a9ef89066b", size = 1448085 },
+    { url = "https://files.pythonhosted.org/packages/47/6d/a3a239e938960df1a662b93d6230d4f3e9b4a22982d060fc38c42f45a56b/black-24.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddacb691cdcdf77b96f549cf9591701d8db36b2f19519373d60d31746068dbf2", size = 1760928 },
+    { url = "https://files.pythonhosted.org/packages/dd/cf/af018e13b0eddfb434df4d9cd1b2b7892bab119f7a20123e93f6910982e8/black-24.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:680359d932801c76d2e9c9068d05c6b107f2584b2a5b88831c83962eb9984c1b", size = 1436875 },
+    { url = "https://files.pythonhosted.org/packages/8d/a7/4b27c50537ebca8bec139b872861f9d2bf501c5ec51fcf897cb924d9e264/black-24.10.0-py3-none-any.whl", hash = "sha256:3bb2b7a1f7b685f85b11fed1ef10f8a9148bceb49853e47a294a3dd963c1dd7d", size = 206898 },
+]
+
+[[package]]
 name = "blinker"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -456,6 +480,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mkdocs-gen-files"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mkdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/85/2d634462fd59136197d3126ca431ffb666f412e3db38fd5ce3a60566303e/mkdocs_gen_files-0.5.0.tar.gz", hash = "sha256:4c7cf256b5d67062a788f6b1d035e157fc1a9498c2399be9af5257d4ff4d19bc", size = 7539 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/0f/1e55b3fd490ad2cecb6e7b31892d27cb9fc4218ec1dab780440ba8579e74/mkdocs_gen_files-0.5.0-py3-none-any.whl", hash = "sha256:7ac060096f3f40bd19039e7277dd3050be9a453c8ac578645844d4d91d7978ea", size = 8380 },
+]
+
+[[package]]
 name = "mkdocs-get-deps"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -546,6 +582,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mypy-extensions"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/a4/1ab47638b92648243faf97a5aeb6ea83059cc3624972ab6b8d2316078d3f/mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782", size = 4433 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d", size = 4695 },
+]
+
+[[package]]
 name = "narwhals"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -624,6 +669,8 @@ dev = [
     { name = "streamlit" },
 ]
 docs = [
+    { name = "black" },
+    { name = "mkdocs-gen-files" },
     { name = "mkdocs-literate-nav" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings-python" },
@@ -643,6 +690,8 @@ dev = [
     { name = "streamlit", specifier = ">=1.41.0" },
 ]
 docs = [
+    { name = "black", specifier = ">=24.10.0" },
+    { name = "mkdocs-gen-files", specifier = ">=0.5.0" },
     { name = "mkdocs-literate-nav", specifier = ">=0.6.1" },
     { name = "mkdocs-material", specifier = ">=9.5.49" },
     { name = "mkdocstrings-python", specifier = ">=1.12.2" },


### PR DESCRIPTION
### Doc work

Continued preparation for doc publishing:

- API reference documentation generation with [mkdocstrings-python](https://mkdocstrings.github.io/python/)
- Doc stubs for the **Examples** wrappers
- Expanded the module docstrings a bit

### API work

- Function rename: `configure_logging()` > `enable_logging()`