### PR TITLE
 doc work + cut image/audio generate flags from `Course.settings`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Welcome
+# Introduction
 
 <div class="grid cards" markdown>
 - :material-clock-fast: [Get started](./get-started.md)
@@ -7,14 +7,10 @@
 <!-- - :octicons-versions-16: [Library `CHANGELOG`](./changelog.md) -->
 </div>
 
-## Inspirations
+## Thanks
 
-The following were all inspirations for the `okcourse` library:
+The following were inspirations for the `okcourse` library:
 
 - [podgenai](https://github.com/impredicative/podgenai)
 - [tts-joinery](https://github.com/drien/tts-joinery)
 - [The Great Courses](https://www.thegreatcourses.com/)
-
-Check 'em out!
-
-:material-peace: *Enjoy!* —[Marsh](https://github.com/mmacy)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,5 +1,0 @@
-# okcourse
-
-::: okcourse
-    options:
-          docstring_section_style: spacy

--- a/examples/snippets/async_openai_snippets.py
+++ b/examples/snippets/async_openai_snippets.py
@@ -1,0 +1,37 @@
+# --8<-- [start:full_openaiasyncgenerator]
+import asyncio
+from okcourse import Course, OpenAIAsyncGenerator
+
+
+async def main() -> None:
+    """Use the OpenAIAsyncGenerator to generate a complete course."""
+
+    # Create a course and initialize the generator
+    course = Course(title="From AGI to ASI: Paperclips, Gray Goo, and You")
+    generator = OpenAIAsyncGenerator(course)
+
+    # Generate all course content - these make calls to the OpenAI API
+    course = await generator.generate_outline(course)
+    course = await generator.generate_lectures(course)
+    course = await generator.generate_image(course)
+    course = await generator.generate_audio(course)
+
+    # Save the course to JSON (Course and nested types are Pydantic models)
+    print(course.model_dump_json(indent=2))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+# --8<-- [end:full_openaiasyncgenerator]
+
+
+async def generate_outline_example() -> Course:
+    """Use the OpenAIAsyncGenerator to generate a course outline."""
+
+    # --8<-- [start:generate_outline]
+    course = Course(title="From AGI to ASI: Paperclips, Gray Goo, and You")
+    generator = OpenAIAsyncGenerator(course)
+    course = await generator.generate_outline(course)
+    # --8<-- [end:generate_outline]
+
+    return course

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ site_description: A library that generates courses containing lectures on any to
 site_url: https://mmacy.github.io/okcourse/
 repo_name: okcourse
 repo_url: https://github.com/mmacy/okcourse
-watch: [README.md, src/okcourse]
+watch: [README.md, src/okcourse, examples/snippets]
 
 theme:
   name: material
@@ -79,7 +79,6 @@ plugins:
     handlers:
       python:
         paths: [src]
-        load_external_modules: false # 'true' picks up __all__ from __init__.py files
         import:
           - https://docs.python.org/3/objects.inv
           - https://docs.pydantic.dev/2.10/objects.inv
@@ -120,6 +119,6 @@ nav:
     - index.md
     - Get started: get-started.md
     - Examples: examples/index.md
-    - okcourse API reference: reference/index.md
+    - API reference: reference/index.md
   - Examples: examples/
   - API reference: reference/

--- a/src/okcourse/constants.py
+++ b/src/okcourse/constants.py
@@ -1,23 +1,26 @@
-"""Immutable constant values used
+"""Values that define constraints related to course content or its generation by course [`generators`][okcourse.generators].
 
-These values define constraints not intended to be modified by [`okcourse`][okcourse] library users. In some cases,
-they're driven by policy or practical considerations rather than technical limitations.
+These constraints are in some cases driven by policy, practical, or financial considerations rather than technical
+limitations.
 
 For example, [`MAX_LECTURES`][okcourse.constants.MAX_LECTURES] is intended to prevent accidental excessive API usage and
 the potentially excessive cost incurred by it.
+
+While you *could* modify these values at runtime, they're here in the `constants` module to encourage you to treat them
+as such. At the very least, you should be wary of the implications of changing them.
 """
 
 MAX_LECTURES: int = 100
 """Maximum number of lectures that may be generated for a course.
 
-This limit is imposed to help avoid accidental excessive API usage and its associated cost rather than being a technical
-limitation.
+This limit is imposed to help avoid a surprise financial burden due to accidental excessive API usage rather than being
+a technical limitation.
 """
 
-AI_DISCLAIMER: str = (
+AI_DISCLOSURE: str = (
     "This is an AI-generated voice, not a human, presenting AI-generated content that might be biased or inaccurate."
 )
-"""Disclaimer required by the [OpenAI usage policy](https://openai.com/policies/usage-policies/) and likely others.
+"""Disclosure required by the [OpenAI usage policy](https://openai.com/policies/usage-policies/) and likely other providers' policies.
 
-This disclaimer is inserted as the first line in the course audio.
+This disclosure is inserted by the `okcourse` library as the opening line in all TTS-generated course audio files.
 """

--- a/src/okcourse/generators/base.py
+++ b/src/okcourse/generators/base.py
@@ -1,3 +1,13 @@
+"""Abstract base class for generator subclasses that interact with AI service provider APIs to create course content.
+
+Subclasses must implement the abstract methods on [`CourseGenerator`][okcourse.generators.base.CourseGenerator] and
+add service provider-specific API interaction logic to generate the outline, lectures, image, and audio for a
+course.
+
+For example, the [`OpenAIAsyncGenerator`][okcourse.generators.openai.OpenAIAsyncGenerator] is an example of a subclass
+that implements the `CourseGenerator`'s abstract methods to interact with OpenAI's API to generate course content.
+"""
+
 from abc import ABC, abstractmethod
 from logging import getLogger as logger
 from ..models import Course
@@ -17,7 +27,8 @@ class CourseGenerator(ABC):
 
     def __init__(self, course: Course):
 
-        self.log: logger = None  # Set this in subclasses so the log messages include the actual generator class name
+        # TODO: Set this automatically in subclasses so the log messages include the actual generator class name
+        self.log: logger = None
         """The logger for the generator."""
 
     @abstractmethod
@@ -40,7 +51,7 @@ class CourseGenerator(ABC):
         """Uses a generative pre-trained transformer (GPT) to generate the lectures in the course outline.
 
         This method requires that the course has had its outline generated with a call to
-        [`generate_outline`](okcourse.generators.base.CourseGenerator.generate_outline) before being passed to this
+        [`generate_outline`][okcourse.generators.base.CourseGenerator.generate_outline] before being passed to this
         method.
 
         Args:

--- a/src/okcourse/generators/openai/async_openai.py
+++ b/src/okcourse/generators/openai/async_openai.py
@@ -1,3 +1,16 @@
+"""The `async_openai` module contains the [`OpenAIAsyncGenerator`][okcourse.generators.openai.async_openai.OpenAIAsyncGenerator] class.
+
+Use the `OpenAIAsyncGenerator` to generate course content asynchronously using the OpenAI API.
+
+Examples:
+
+Generate a full course, including its outline, lectures, cover image, and audio file:
+
+ ```python
+ --8<-- "examples/snippets/async_openai_snippets.py:full_openaiasyncgenerator"
+ ```
+"""
+
 import asyncio
 import base64
 import io
@@ -13,7 +26,7 @@ from openai.types.image_model import ImageModel
 from pydub import AudioSegment
 
 from ...constants import (
-    AI_DISCLAIMER,
+    AI_DISCLOSURE,
     MAX_LECTURES,
 )
 from ...models import Course, CourseOutline, Lecture
@@ -22,12 +35,12 @@ from ...utils import (
     download_tokenizer,
     extract_literal_values_from_member,
     extract_literal_values_from_type,
+    get_logger,
+    get_top_level_version,
     sanitize_filename,
     split_text_into_chunks,
     swap_words,
     tokenizer_available,
-    get_logger,
-    get_top_level_version,
 )
 from ..base import CourseGenerator
 
@@ -63,15 +76,22 @@ class OpenAIAsyncGenerator(CourseGenerator):
         self.tts_voices: list[str] = extract_literal_values_from_member(SpeechCreateParams, "voice")
 
     async def generate_outline(self, course: Course) -> Course:
-        """Generates a course outline for the course based on its title and `num_lectures`in the settings.
+        """Generates a course outline for the course based on its title and [`num_lectures` in its `settings`.
 
-        Set the course `title` attribute before calling this method.
+        Set the course's [`title`][okcourse.models.Course.title] attribute before calling this method.
 
         Returns:
             Course: The result of the generation process with its `course.outline` attribute set.
 
         Raises:
             ValueError: If the course has no title.
+
+        Examples:
+
+        ```python
+        --8<-- "examples/snippets/async_openai_snippets.py:generate_outline"
+        ```
+
         """
         if not course.title or course.title.strip() == "":
             msg = "The given Course has no title. Set the course's 'title' attribute before calling this method."
@@ -266,7 +286,7 @@ class OpenAIAsyncGenerator(CourseGenerator):
 
         # Combine all lecture texts, including titles, preceded by the disclosure that it's all AI-generated
         course_text = (
-            AI_DISCLAIMER
+            AI_DISCLOSURE
             + "\n\n"
             + course.title
             + "\n\n".join(f"Lecture {lecture.number}:\n\n{lecture.text}" for lecture in course.lectures)


### PR DESCRIPTION
- more docstring work
- added first of the code snippets (`examples/snippets/*`) for ingestion into docstrings **Examples:** sections and that also will be tested by CI
- cut `bool` image and audio generation flags from `CourseSettings` - that's already explicit by calling (or not) the `generate_image()` and `generate_audio()` methods on the generator