### PR TITLE
copyable code blocks + lecture prompt tweak (direct, scholarly)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ theme:
     - content.action.edit
     - content.action.view
     - content.code.annotate
+    - content.code.copy
     - header.autohide
     - search.share
     - search.suggest

--- a/src/okcourse/models.py
+++ b/src/okcourse/models.py
@@ -78,8 +78,8 @@ class CourseSettings(BaseModel):
         "Generate the complete unabridged text for a lecture titled '${lecture_title}' in a graduate-level course "
         "named '${course_title}'. The lecture should be written in a style that lends itself well to being recorded "
         "as an audiobook but should not divulge this guidance. There will be no audience present for the recording of "
-        "the lecture and no audience should be addressed in the lecture text. Cover the lecture topic in great detail "
-        "while keeping in mind the advanced education level of the listeners of the lecture. "
+        "the lecture and no audience should be addressed in the lecture text. Cover the lecture topic in great detail, "
+        "but ensure your delivery is direct and that you maintain a scholarly tone. "
         "Omit Markdown from the lecture text as well as any tags, formatting markers, or headings that might interfere "
         "with text-to-speech processing. Ensure the content is original and does not duplicate content from the other "
         "lectures in the series:\n${course_outline}",

--- a/src/okcourse/utils.py
+++ b/src/okcourse/utils.py
@@ -162,7 +162,6 @@ def get_duration_string_from_seconds(seconds: float) -> str:
 
 
 LLM_SMELLS: dict[str, str] = {
-    # "crucial": "important",  # TODO: Uncomment when we can handle phrases (currently breaks due to a/an mismatch).
     "delve": "dig",
     "delved": "dug",
     "delves": "digs",
@@ -173,6 +172,9 @@ LLM_SMELLS: dict[str, str] = {
     "utilization": "usage",
     "meticulous": "careful",
     "meticulously": "carefully",
+    # crucial
+    # underscore
+    # paramount
 }
 """Dictionary mapping words overused by some large language models to their simplified 'everyday' forms.
 


### PR DESCRIPTION
- Code blocks in docs now have a copy button at upper-right of block.
- Tweak to the `text_model_lecture_prompt` that lessens the marketing-speak some (anecdotal, but noticeable). Replaced the bit about keeping in mind the "advanced education level of the listeners" with the stipulation to "ensure your delivery is direct and that you maintain a scholarly tone."

   The former ("advanced education level of the listeners") resulted in much too flowery commentary, as if it was attempting to *sound* smart by padding the response with a bunch of fancy words rather than addressing an audience that has some knowledge of the subject matter, which was the actual intent of that section of prompt. The prompt will continue to be iterated upon as it still produces content that's too surface-level, but we'll see how this goes for little while before changing it again. The model's response styles vary somewhat throughout day without change the prompt at all, so I've found it needs to bake a bit before I'm able to make a "vibe" call on it.