### PR TITLE
num_subtopics + push some code up to CourseGenerator(ABC) + support diff. models for outline and lectur

### DIFF
--- a/examples/cli_example_async.py
+++ b/examples/cli_example_async.py
@@ -81,7 +81,7 @@ async def main():
         out_dir = await async_prompt(
             questionary.text,
             "Enter a directory for the course output:",
-            default=course.settings.output_directory,
+            default=str(course.settings.output_directory),
         )
         course.settings.output_directory = Path(out_dir)
 

--- a/examples/cli_example_async.py
+++ b/examples/cli_example_async.py
@@ -37,7 +37,7 @@ async def main():
     print("============================")
 
     course = Course()
-    course.settings.output_directory = os.path.expanduser("~/.okcourse_files")
+    course.settings.output_directory = Path("~/.okcourse_files").expanduser().resolve()
     course.settings.log_to_file = True
 
     topic = await async_prompt(questionary.text, "Enter a course topic:")

--- a/examples/cli_example_async.py
+++ b/examples/cli_example_async.py
@@ -54,11 +54,20 @@ async def main():
             "How many lectures should be in the course?",
             default=str(course.settings.num_lectures),
         )
+        course.settings.num_subtopics = await async_prompt(
+            questionary.text,
+            "How many sub-topics per lecture?",
+            default=str(course.settings.num_subtopics),
+        )
         try:
             course.settings.num_lectures = int(course.settings.num_lectures)
+            course.settings.num_subtopics = int(course.settings.num_subtopics)
             if course.settings.num_lectures <= 0:
                 print("There must be at least one (1) lecture in the series.")
                 continue  # Input is invalid
+            if course.settings.num_subtopics <= 0:
+                print("There must be at least one (1) sub-topic per lecture.")
+                continue
         except ValueError:
             print("Enter a valid number greater than 0.")
             continue  # Input is invalid

--- a/src/okcourse/generators/base.py
+++ b/src/okcourse/generators/base.py
@@ -12,7 +12,7 @@ from abc import ABC, abstractmethod
 from logging import getLogger as logger
 from pathlib import Path
 from ..models import Course
-from ..utils import get_logger
+from ..utils import get_logger, get_top_level_version
 
 
 class CourseGenerator(ABC):
@@ -32,9 +32,10 @@ class CourseGenerator(ABC):
         self.log: logger = None
         """The logger for the generator."""
 
-        self._initialize_logger(course)
+        self._init_logger(course)
+        self._init_generator_info(course)
 
-    def _initialize_logger(self, course: Course) -> None:
+    def _init_logger(self, course: Course) -> None:
         """Creates a logger whose name is derived from the CourseGenerator *subclass* at runtime."""
 
         if course.settings.log_level:
@@ -49,6 +50,13 @@ class CourseGenerator(ABC):
 
             if course.settings.log_to_file:
                 self.log.info(f"Logging to file: {log_file}")
+
+    def _init_generator_info(self, course: Course) -> None:
+        """Record the generator type and version in the Course object's generation_info."""
+
+        course.generation_info.generator_type = f"{self.__module__}.{type(self).__name__}"
+        course.generation_info.okcourse_version = get_top_level_version("okcourse")
+
 
     @abstractmethod
     def generate_outline(self, course: Course) -> Course:

--- a/src/okcourse/generators/base.py
+++ b/src/okcourse/generators/base.py
@@ -33,7 +33,7 @@ class CourseGenerator(ABC):
         """The logger for the generator."""
 
         self._init_logger(course)
-
+        self._init_generator_info(course)
 
     def _init_logger(self, course: Course) -> None:
         """Creates a logger whose name is derived from the CourseGenerator *subclass* at runtime."""
@@ -56,7 +56,6 @@ class CourseGenerator(ABC):
 
         course.generation_info.generator_type = f"{self.__module__}.{type(self).__name__}"
         course.generation_info.okcourse_version = get_top_level_version("okcourse")
-
 
     @abstractmethod
     def generate_outline(self, course: Course) -> Course:

--- a/src/okcourse/generators/base.py
+++ b/src/okcourse/generators/base.py
@@ -33,7 +33,7 @@ class CourseGenerator(ABC):
         """The logger for the generator."""
 
         self._init_logger(course)
-        self._init_generator_info(course)
+
 
     def _init_logger(self, course: Course) -> None:
         """Creates a logger whose name is derived from the CourseGenerator *subclass* at runtime."""

--- a/src/okcourse/generators/openai/async_openai.py
+++ b/src/okcourse/generators/openai/async_openai.py
@@ -57,9 +57,6 @@ class OpenAIAsyncGenerator(CourseGenerator):
         """
         super().__init__(course)
 
-        course.generation_info.generator_type = __name__
-        course.generation_info.okcourse_version = get_top_level_version("okcourse")
-
         self.client = AsyncOpenAI()
 
         # Populate lists of available models and voices for possible use presenting options to the user
@@ -67,21 +64,6 @@ class OpenAIAsyncGenerator(CourseGenerator):
         self.text_models: list[str] = extract_literal_values_from_type(ChatModel)
         self.speech_models: list[str] = extract_literal_values_from_type(SpeechModel)
         self.tts_voices: list[str] = extract_literal_values_from_member(SpeechCreateParams, "voice")
-
-        # OpenAI pricing as of 2024-01-02
-        # gpt-4o    | $0.00250 / 1K input tokens
-        # gpt-4o    | $0.01000 / 1K output tokens
-        # dall-e-3  | $0.040 / image Standard 1024×1024
-        # tts-1     | $0.015 / 1K characters
-        # {
-        #     "okcourse_version": "0.1.8",
-        #     "input_token_count": 2079,
-        #     "output_token_count": 2710,
-        #     "tts_character_count": 15896,
-        #     "num_images_generated": 1,
-        #     "audio_file_path": "/Users/mmacy/.okcourse_files/calculating_openai_api_usage_cost.mp3",
-        #     "image_file_path": "/Users/mmacy/.okcourse_files/calculating_openai_api_usage_cost.png"
-        # }
 
     async def generate_outline(self, course: Course) -> Course:
         """Generates a course outline based on its `title` and other [`settings`][okcourse.models.Course.settings].
@@ -346,7 +328,9 @@ class OpenAIAsyncGenerator(CourseGenerator):
             )
 
             if course.generation_info.image_file_path and course.generation_info.image_file_path.exists():
-                composer_tag = f"{course.settings.text_model} & {course.settings.tts_model} & {course.settings.image_model}"
+                composer_tag = (
+                    f"{course.settings.text_model} & {course.settings.tts_model} & {course.settings.image_model}"
+                )
                 cover_tag = str(course.generation_info.image_file_path)
             else:
                 composer_tag = f"{course.settings.text_model} & {course.settings.tts_model}"

--- a/src/okcourse/generators/openai/async_openai.py
+++ b/src/okcourse/generators/openai/async_openai.py
@@ -60,17 +60,6 @@ class OpenAIAsyncGenerator(CourseGenerator):
         course.generation_info.generator_type = __name__
         course.generation_info.okcourse_version = get_top_level_version("okcourse")
 
-        if course.settings.log_level:
-            log_file = course.settings.output_directory / Path(__name__).with_suffix(".log")
-            self.log = get_logger(
-                source_name=__name__,
-                level=course.settings.log_level,
-                file_path=log_file if course.settings.log_to_file else None,
-            )
-
-            if course.settings.log_to_file:
-                self.log.info(f"Logging to file: {log_file}")
-
         self.client = AsyncOpenAI()
 
         # Populate lists of available models and voices for possible use presenting options to the user

--- a/src/okcourse/models.py
+++ b/src/okcourse/models.py
@@ -51,13 +51,20 @@ class CourseSettings(BaseModel):
     # TODO: Add a setting to specify which AI service provider to use for generation.
 
     num_lectures: int = Field(4, description="The number of lectures that should generated for for the course.")
+    num_subtopics: int = Field(
+        4, description="The number of subtopics that should be generated for each lecture."
+    )
     output_directory: Path = Field(
         Path("~/.okcourse").expanduser(),  # TODO: Make this cross-platform-friendly
         description="Directory for saving generated course content.",
     )
-    text_model: str = Field(
+    text_model_outline: str = Field(
         "gpt-4o",
-        description="The ID of the text generation model to use.",
+        description="The ID of the text generation model to use for generating course outlines.",
+    )
+    text_model_lecture: str = Field(
+        "gpt-4o",
+        description="The ID of the text generation model to use for generating course lectures.",
     )
     text_model_system_prompt: str = Field(
         "You are an esteemed college professor and expert in your field who typically lectures graduate students. "
@@ -70,7 +77,7 @@ class CourseSettings(BaseModel):
     )
     text_model_outline_prompt: str = Field(
         "Provide a detailed outline for ${num_lectures} lectures in a graduate-level course on '${course_title}'. "
-        "List each lecture title numbered. Each lecture should have four subtopics listed after the "
+        "List each lecture title numbered. Each lecture should have ${num_subtopics} subtopics listed after the "
         "lecture title. Respond only with the outline, omitting any other commentary.",
         description="The `user` prompt containing the course outline generation instructions for the language model.",
     )

--- a/src/okcourse/utils.py
+++ b/src/okcourse/utils.py
@@ -89,8 +89,9 @@ def download_tokenizer() -> bool:
 def split_text_into_chunks(text: str, max_chunk_size: int = 4096) -> list[str]:
     """Splits text into chunks of approximately `max_chunk_size` characters.
 
-    The first time you call this function, it will check the default download location for the NLTK 'punkt_tab' tokenizer.
-    If the tokenizer is not found, it will attempt to download it. Subsequent calls will not re-download the tokenizer.
+    The first time you call this function, it will check the default download location for the NLTK 'punkt_tab'
+    tokenizer. If the tokenizer is not found, it will attempt to download it. Subsequent calls will not re-download the
+    tokenizer.
 
     Args:
         text: The text to split.
@@ -182,7 +183,8 @@ LLM_SMELLS: dict[str, str] = {
 
 Words in the keys may be replaced by their simplified forms in generated lecture text to help reduce \"LLM smell.\"
 
-This dictionary is appropriate for use as the `replacements` parameter in the [`swap_words`][okcourse.utils.swap_words] function.
+This dictionary is appropriate for use as the `replacements` parameter in the [`swap_words`][okcourse.utils.swap_words]
+function.
 """
 
 
@@ -211,7 +213,7 @@ def swap_words(text: str, replacements: dict[str, str]) -> str:
 
 
 def extract_literal_values_from_type(typ: object) -> list[str]:
-    """Unwraps a [`Literal`][typing.Literal] or any nested [`Union`][typing.Union] containing literals and returns the `Literal` values."""
+    """Unwraps a [`Literal`][typing.Literal] or any nested [`Union`][typing.Union] containing literals and returns the `Literal` values."""  # noqa: E501
 
     def unwrap_literal(t: object):
         origin = get_origin(t)
@@ -232,8 +234,8 @@ def extract_literal_values_from_type(typ: object) -> list[str]:
 def extract_literal_values_from_member(cls: Any, member: str) -> list[Any]:
     """Extracts the [`Literal`][typing.Literal] values of a specified member in a class or [`TypedDict`][typing.TypedDict].
 
-    If the member's type is a `Literal` or contains literals within a [`Union`][typing.Union] like `Optional[Literal[...]]`, the
-    function extracts and returns all the `Literal` values.
+    If the member's type is a `Literal` or contains literals within a [`Union`][typing.Union] like
+    `Optional[Literal[...]]`, the function extracts and returns all the `Literal` values.
     """
     type_hints = get_type_hints(cls)
 
@@ -290,7 +292,8 @@ def time_tracker(target_object: object, attribute_name: str):
 
     Examples:
 
-    Record time elapsed generating a course's outline in the course's [`CourseGenerationInfo`][okcourse.models.CourseGenerationInfo]:
+    Record time elapsed generating a course's outline in the course's
+    [`CourseGenerationInfo`][okcourse.models.CourseGenerationInfo]:
 
     ```python
     async def generate_outline(self, course: Course) -> Course:


### PR DESCRIPTION
- new `course_settings.num_subtopics` attribute modifies user prompt when requesting a course outline (was hardcoded at 4 subtopics)
- pushed code shareable between all course generators (logger and generation_info init) to the base `CourseGenerator(ABC)`
- split text model setting into outline and lecture settings (`text_model_outline` and `text_model_lecture`) in case we want to use different models for generating those, like `gpt-4o` for the outline and `o1` for the lectures