### PR TITLE
switch to mutagen from pydub (removes ffmpeg dependency)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ The async version of the `okcourse` OpenAI generator can produce a **1.5-hour** 
 ## Prerequisites
 
 - [Python 3.12+](https://python.org)
-- [FFmpeg](https://ffmpeg.org/)
 - [OpenAI API key](https://platform.openai.com/docs/quickstart)
 
 ## Install uv (optional)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "okcourse"
-version = "0.1.8"
+version = "0.1.9"
 description = "Generate audiobook-style courses in MP3 format with lectures on any topic using Python and the OpenAI API."
 readme = "README.md"
 authors = [
@@ -8,9 +8,9 @@ authors = [
 ]
 requires-python = ">=3.12"
 dependencies = [
+    "mutagen>=1.47.0",
     "nltk>=3.9.1",
     "openai>=1.57.2",
-    "pydub>=0.25.1",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -623,6 +623,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mutagen"
+version = "1.47.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/e6/64bc71b74eef4b68e61eb921dcf72dabd9e4ec4af1e11891bbd312ccbb77/mutagen-1.47.0.tar.gz", hash = "sha256:719fadef0a978c31b4cf3c956261b3c58b6948b32023078a2117b1de09f0fc99", size = 1274186 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/7a/620f945b96be1f6ee357d211d5bf74ab1b7fe72a9f1525aafbfe3aee6875/mutagen-1.47.0-py3-none-any.whl", hash = "sha256:edd96f50c5907a9539d8e5bba7245f62c9f520aef333d13392a79a4f70aca719", size = 194391 },
+]
+
+[[package]]
 name = "mypy-extensions"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -695,12 +704,12 @@ wheels = [
 
 [[package]]
 name = "okcourse"
-version = "0.1.8"
+version = "0.1.9"
 source = { editable = "." }
 dependencies = [
+    { name = "mutagen" },
     { name = "nltk" },
     { name = "openai" },
-    { name = "pydub" },
 ]
 
 [package.dev-dependencies]
@@ -723,9 +732,9 @@ docs = [
 
 [package.metadata]
 requires-dist = [
+    { name = "mutagen", specifier = ">=1.47.0" },
     { name = "nltk", specifier = ">=3.9.1" },
     { name = "openai", specifier = ">=1.57.2" },
-    { name = "pydub", specifier = ">=0.25.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -991,15 +1000,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/ca/40e14e196864a0f61a92abb14d09b3d3da98f94ccb03b49cf51688140dab/pydeck-0.9.1.tar.gz", hash = "sha256:f74475ae637951d63f2ee58326757f8d4f9cd9f2a457cf42950715003e2cb605", size = 3832240 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/4c/b888e6cf58bd9db9c93f40d1c6be8283ff49d88919231afe93a6bcf61626/pydeck-0.9.1-py2.py3-none-any.whl", hash = "sha256:b3f75ba0d273fc917094fa61224f3f6076ca8752b93d46faf3bcfd9f9d59b038", size = 6900403 },
-]
-
-[[package]]
-name = "pydub"
-version = "0.25.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/9a/e6bca0eed82db26562c73b5076539a4a08d3cffd19c3cc5913a3e61145fd/pydub-0.25.1.tar.gz", hash = "sha256:980a33ce9949cab2a569606b65674d748ecbca4f0796887fd6f46173a7b0d30f", size = 38326 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/53/d78dc063216e62fc55f6b2eebb447f6a4b0a59f55c8406376f76bf959b08/pydub-0.25.1-py2.py3-none-any.whl", hash = "sha256:65617e33033874b59d87db603aa1ed450633288aefead953b30bded59cb599a6", size = 32327 },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #35

- Switch to [Mutagen](https://github.com/quodlibet/mutagen) for tagging course audio files
- Remove PyDub (and thus FFmpeg) dependency
- Concat TTS-generated lecture chunks manually and save file straight to disk (much faster!)

TODO in future PR:

- [ ] Refactor audio processing and other utils into a new utils package with purposefully named modules. 