### PR TITLE
unit tests (first of many) + new CoursePromptSet model and feature

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,10 @@
 {
     "python.autoComplete.extraPaths": [
         "src"
-    ]
+    ],
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
 }

--- a/examples/cli_example_async.py
+++ b/examples/cli_example_async.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import questionary
 
 from okcourse import Course, OpenAIAsyncGenerator
-from okcourse.utils.string_utils import sanitize_filename, get_duration_string_from_seconds
+from okcourse.utils.text_utils import sanitize_filename, get_duration_string_from_seconds
 
 
 async def async_prompt(prompt_func, *args, **kwargs):

--- a/examples/streamlit_example.py
+++ b/examples/streamlit_example.py
@@ -5,7 +5,7 @@ import streamlit as st
 
 from okcourse import Course, CourseSettings, OpenAIAsyncGenerator
 from okcourse.constants import MAX_LECTURES
-from okcourse.prompt_library import ACADEMIC, GAME_MASTER
+from okcourse.prompt_library import PROMPT_COLLECTION, ACADEMIC, GAME_MASTER
 from okcourse.utils.log_utils import get_logger
 from okcourse.utils.text_utils import get_duration_string_from_seconds
 
@@ -18,7 +18,7 @@ async def main():
     # Initialize session state variables
     if "course" not in st.session_state:
         log.info("Initializing session state with new 'Course' instance...")
-        settings = CourseSettings(prompts=GAME_MASTER)
+        settings = CourseSettings(prompts=ACADEMIC)
         st.session_state.course = Course(settings=settings)
     if "do_generate_outline" not in st.session_state:
         log.info("Initializing session state with outline generation flag set to 'False'...")
@@ -28,6 +28,15 @@ async def main():
         st.session_state.do_generate_course = False
 
     course = st.session_state.course
+
+    # Dynamically generate prompt selection options
+    prompt_options = {
+        prompt.description.replace("_", " ").capitalize(): prompt for prompt in PROMPT_COLLECTION
+    }
+    selected_prompt_name = st.selectbox("Select the course prompt style:", options=list(prompt_options.keys()))
+    selected_prompt = prompt_options[selected_prompt_name]
+    course.settings.prompts = selected_prompt
+
     course.title = st.text_input("Enter the course topic:")
     course.settings.num_lectures = st.number_input(
         "Number of lectures:", min_value=1, max_value=MAX_LECTURES, value=20, step=1

--- a/examples/streamlit_example.py
+++ b/examples/streamlit_example.py
@@ -3,9 +3,9 @@ from pathlib import Path
 
 import streamlit as st
 
-from okcourse import Course, CourseSettings, OpenAIAsyncGenerator
+from okcourse import Course, OpenAIAsyncGenerator
 from okcourse.constants import MAX_LECTURES
-from okcourse.prompt_library import PROMPT_COLLECTION, ACADEMIC, GAME_MASTER
+from okcourse.prompt_library import PROMPT_COLLECTION
 from okcourse.utils.log_utils import get_logger
 from okcourse.utils.text_utils import get_duration_string_from_seconds
 
@@ -18,8 +18,7 @@ async def main():
     # Initialize session state variables
     if "course" not in st.session_state:
         log.info("Initializing session state with new 'Course' instance...")
-        settings = CourseSettings(prompts=ACADEMIC)
-        st.session_state.course = Course(settings=settings)
+        st.session_state.course = Course()
     if "do_generate_outline" not in st.session_state:
         log.info("Initializing session state with outline generation flag set to 'False'...")
         st.session_state.do_generate_outline = False

--- a/examples/streamlit_example.py
+++ b/examples/streamlit_example.py
@@ -3,10 +3,11 @@ from pathlib import Path
 
 import streamlit as st
 
-from okcourse import Course, OpenAIAsyncGenerator
+from okcourse import Course, CourseSettings, OpenAIAsyncGenerator
 from okcourse.constants import MAX_LECTURES
+from okcourse.prompt_library import ACADEMIC, GAME_MASTER
 from okcourse.utils.log_utils import get_logger
-from okcourse.utils.string_utils import get_duration_string_from_seconds
+from okcourse.utils.text_utils import get_duration_string_from_seconds
 
 
 async def main():
@@ -17,7 +18,8 @@ async def main():
     # Initialize session state variables
     if "course" not in st.session_state:
         log.info("Initializing session state with new 'Course' instance...")
-        st.session_state.course = Course()
+        settings = CourseSettings(prompts=GAME_MASTER)
+        st.session_state.course = Course(settings=settings)
     if "do_generate_outline" not in st.session_state:
         log.info("Initializing session state with outline generation flag set to 'False'...")
         st.session_state.do_generate_outline = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ build-backend = "hatchling.build"
 [dependency-groups]
 dev = [
     "aiofiles>=24.1.0",
+    "pytest>=8.3.4",
     "questionary>=2.0.1",
     "streamlit>=1.41.0",
 ]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = --tb=short
+testpaths = tests
+plugins = uv

--- a/src/okcourse/__init__.py
+++ b/src/okcourse/__init__.py
@@ -5,7 +5,7 @@ Given a course title, a course generator like the [`OpenAIAsyncCourseGenerator`]
 API:
 
 - [Course outline][okcourse.CourseOutline]
-- [Lecture text][okcourse.Lecture] for the topics in the outline
+- [Lecture text][okcourse.CourseLecture] for the topics in the outline
 - [Cover image][okcourse.CourseGenerator.generate_image] for the audio file album art
 - [Audio file][okcourse.generators.base.CourseGenerator.generate_audio] from the lecture text
 """
@@ -16,20 +16,22 @@ from .generators import CourseGenerator, OpenAIAsyncGenerator
 from .models import (
     Course,
     CourseGenerationInfo,
+    CourseLecture,
+    CourseLectureTopic,
     CourseOutline,
+    CoursePromptSet,
     CourseSettings,
-    Lecture,
-    LectureTopic,
 )
 
 __all__ = [
     "Course",
     "CourseGenerationInfo",
     "CourseGenerator",
+    "CourseLecture",
+    "CourseLectureTopic",
     "CourseOutline",
+    "CoursePromptSet",
     "CourseSettings",
-    "Lecture",
-    "LectureTopic",
     "OpenAIAsyncGenerator",
 ]
 

--- a/src/okcourse/generators/base.py
+++ b/src/okcourse/generators/base.py
@@ -12,6 +12,7 @@ from abc import ABC, abstractmethod
 from logging import getLogger as logger
 from pathlib import Path
 from ..models import Course
+from ..prompt_library import ACADEMIC
 from ..utils.log_utils import get_logger, get_top_level_version
 
 
@@ -34,6 +35,7 @@ class CourseGenerator(ABC):
 
         self._init_logger(course)
         self._init_generator_info(course)
+        self._init_prompts(course)
 
     def _init_logger(self, course: Course) -> None:
         """Creates a logger whose name is derived from the CourseGenerator *subclass* at runtime."""
@@ -56,6 +58,10 @@ class CourseGenerator(ABC):
 
         course.generation_info.generator_type = f"{self.__module__}.{type(self).__name__}"
         course.generation_info.okcourse_version = get_top_level_version("okcourse")
+
+    def _init_prompts(self, course: Course) -> None:
+        if not course.settings.prompts:
+            course.settings.prompts = ACADEMIC
 
     @abstractmethod
     def generate_outline(self, course: Course) -> Course:

--- a/src/okcourse/generators/openai/async_openai.py
+++ b/src/okcourse/generators/openai/async_openai.py
@@ -21,7 +21,7 @@ from ...models import Course, CourseOutline, Lecture
 from ...utils.audio_utils import combine_mp3_buffers
 from ...utils.log_utils import get_top_level_version, time_tracker
 from ...utils.misc_utils import extract_literal_values_from_member, extract_literal_values_from_type
-from ...utils.string_utils import (
+from ...utils.text_utils import (
     LLM_SMELLS,
     download_tokenizer,
     sanitize_filename,
@@ -91,8 +91,7 @@ class OpenAIAsyncGenerator(CourseGenerator):
 
         course.settings.output_directory = course.settings.output_directory.expanduser().resolve()
 
-        outline_prompt_template = Template(course.settings.text_model_outline_prompt)
-        outline_prompt = outline_prompt_template.substitute(
+        outline_prompt = Template(course.settings.prompts.outline).substitute(
             num_lectures=course.settings.num_lectures,
             course_title=course.title,
             num_subtopics=course.settings.num_subtopics,
@@ -103,7 +102,7 @@ class OpenAIAsyncGenerator(CourseGenerator):
             outline_completion = await self.client.beta.chat.completions.parse(
                 model=course.settings.text_model_outline,
                 messages=[
-                    {"role": "system", "content": course.settings.text_model_system_prompt},
+                    {"role": "system", "content": course.settings.prompts.system},
                     {"role": "user", "content": outline_prompt},
                 ],
                 response_format=CourseOutline,
@@ -140,8 +139,7 @@ class OpenAIAsyncGenerator(CourseGenerator):
         if not topic:
             raise ValueError(f"No topic found for lecture number {lecture_number}")
 
-        lecture_prompt_template = Template(course.settings.text_model_lecture_prompt)
-        lecture_prompt = lecture_prompt_template.substitute(
+        lecture_prompt = Template(course.settings.prompts.lecture).substitute(
             lecture_title=topic.title,
             course_title=course.title,
             course_outline=str(course.outline),
@@ -153,7 +151,7 @@ class OpenAIAsyncGenerator(CourseGenerator):
         response = await self.client.chat.completions.create(
             model=course.settings.text_model_lecture,
             messages=[
-                {"role": "system", "content": course.settings.text_model_system_prompt},
+                {"role": "system", "content": course.settings.prompts.system},
                 {"role": "user", "content": lecture_prompt},
             ],
             max_completion_tokens=15000,
@@ -208,13 +206,11 @@ class OpenAIAsyncGenerator(CourseGenerator):
         """
 
         course.settings.output_directory = course.settings.output_directory.expanduser().resolve()
-        image_prompt_template = Template(course.settings.image_model_prompt)
-        image_prompt = image_prompt_template.substitute(course_title=course.title)
         try:
             with time_tracker(course.generation_info, "image_gen_elapsed_seconds"):
                 image_response = await self.client.images.generate(
                     model=course.settings.image_model,
-                    prompt=image_prompt,
+                    prompt=Template(course.settings.prompts.image).substitute(course_title=course.title),
                     n=1,
                     size="1024x1024",
                     response_format="b64_json",

--- a/src/okcourse/generators/openai/async_openai.py
+++ b/src/okcourse/generators/openai/async_openai.py
@@ -17,7 +17,7 @@ from ...constants import (
     AI_DISCLOSURE,
     MAX_LECTURES,
 )
-from ...models import Course, CourseOutline, Lecture
+from ...models import Course, CourseOutline, CourseLecture
 from ...utils.audio_utils import combine_mp3_buffers
 from ...utils.log_utils import get_top_level_version, time_tracker
 from ...utils.misc_utils import extract_literal_values_from_member, extract_literal_values_from_type
@@ -122,7 +122,7 @@ class OpenAIAsyncGenerator(CourseGenerator):
         course.outline = generated_outline
         return course
 
-    async def _generate_lecture(self, course: Course, lecture_number: int) -> Lecture:
+    async def _generate_lecture(self, course: Course, lecture_number: int) -> CourseLecture:
         """Generates a lecture for the topic with the specified number in the given outline.
 
         Args:
@@ -166,7 +166,7 @@ class OpenAIAsyncGenerator(CourseGenerator):
             f"Got lecture text for topic {topic.number}/{len(course.outline.topics)} "
             f"@ {len(lecture_text)} chars: {topic.title}."
         )
-        return Lecture(**topic.model_dump(), text=lecture_text)
+        return CourseLecture(**topic.model_dump(), text=lecture_text)
 
     async def generate_lectures(self, course: Course) -> Course:
         """Generates the text for the lectures in the course outline in the settings.

--- a/src/okcourse/models.py
+++ b/src/okcourse/models.py
@@ -68,6 +68,34 @@ class CoursePromptSet(BaseModel):
     )
 
 
+_DEFAULT_PROMPT_SET = CoursePromptSet(
+    description="Academic Lecture Series",
+    system="You are an esteemed college professor and expert in your field who typically lectures graduate students. "
+    "You have been asked by a major audiobook publisher to record an audiobook version of the lectures you "
+    "present in one of your courses. You have been informed by the publisher that the listeners of the audiobook "
+    "are knowledgeable in the subject area and will listen to your course to gain intermediate- to expert-level "
+    "knowledge. Your lecture style is professional, direct, and deeply technical.",
+    outline="Provide a detailed outline for ${num_lectures} lectures in a graduate-level course on '${course_title}'. "
+    "List each lecture title numbered. Each lecture should have ${num_subtopics} subtopics listed after the "
+    "lecture title. Respond only with the outline, omitting any other commentary.",
+    lecture="Generate the complete unabridged text for a lecture titled '${lecture_title}' in a graduate-level course "
+    "named '${course_title}'. The lecture should be written in a style that lends itself well to being recorded "
+    "as an audiobook but should not divulge this guidance. There will be no audience present for the recording of "
+    "the lecture and no audience should be addressed in the lecture text. Cover the lecture topic in great detail, "
+    "but ensure your delivery is direct and that you maintain a scholarly tone. "
+    "Omit Markdown from the lecture text as well as any tags, formatting markers, or headings that might interfere "
+    "with text-to-speech processing. Ensure the content is original and does not duplicate content from the other "
+    "lectures in the series:\n${course_outline}",
+    image="Create a cover art image for the college lecture series titled '${course_title}'. Fill the entire canvas "
+    "with an academic art style using muted colors that reflects the course material.",
+)
+"""The default "academic" set of prompts used by a course generator like the [`OpenAIAsyncGenerator`][okcourse.OpenAIAsyncGenerator].
+
+You should not reference this prompt set directly - use the [`ACADEMIC`][okcourse.prompt_library.ACADEMIC] prompt set in
+the `prompt_library` module instead (it's an alias of this one).
+"""
+
+
 class CourseSettings(BaseModel):
     """Runtime-modifiable settings that configure the behavior of a course [`generator`][okcourse.generators].
 
@@ -79,7 +107,8 @@ class CourseSettings(BaseModel):
     """
 
     prompts: CoursePromptSet = Field(
-        default_factory=CoursePromptSet, description="The prompts that guide the AI models in course generation."
+        _DEFAULT_PROMPT_SET,
+        description="The prompts that guide the AI models in course generation.",
     )
     num_lectures: int = Field(4, description="The number of lectures that should generated for for the course.")
     num_subtopics: int = Field(4, description="The number of subtopics that should be generated for each lecture.")

--- a/src/okcourse/prompt_library.py
+++ b/src/okcourse/prompt_library.py
@@ -1,0 +1,51 @@
+"""A collection of prompt sets for different types of courses."""
+
+from string import Template
+from .models import CoursePrompts
+
+ACADEMIC = CoursePrompts(
+    system="You are an esteemed college professor and expert in your field who typically lectures graduate students. "
+    "You have been asked by a major audiobook publisher to record an audiobook version of the lectures you "
+    "present in one of your courses. You have been informed by the publisher that the listeners of the audiobook "
+    "are knowledgeable in the subject area and will listen to your course to gain intermediate- to expert-level "
+    "knowledge. Your lecture style is professional, direct, and deeply technical.",
+    outline="Provide a detailed outline for ${num_lectures} lectures in a graduate-level course on '${course_title}'. "
+        "List each lecture title numbered. Each lecture should have ${num_subtopics} subtopics listed after the "
+        "lecture title. Respond only with the outline, omitting any other commentary.",
+    lecture="Generate the complete unabridged text for a lecture titled '${lecture_title}' in a graduate-level course "
+        "named '${course_title}'. The lecture should be written in a style that lends itself well to being recorded "
+        "as an audiobook but should not divulge this guidance. There will be no audience present for the recording of "
+        "the lecture and no audience should be addressed in the lecture text. Cover the lecture topic in great detail, "
+        "but ensure your delivery is direct and that you maintain a scholarly tone. "
+        "Omit Markdown from the lecture text as well as any tags, formatting markers, or headings that might interfere "
+        "with text-to-speech processing. Ensure the content is original and does not duplicate content from the other "
+        "lectures in the series:\n${course_outline}",
+    image="Create an image in the style of cover art for an audio recording of a college lecture series shown in an "
+        "online academic catalog. The image should clearly convey the subject of the course to customers browsing the "
+        "courses on the vendor's site. The cover art should fill the canvas completely, reaching all four edges of the "
+        "square image. Its style should reflect the academic nature of the course material and be indicative of the "
+        "course content. The title of the course is '${course_title}'",
+)
+
+GAME_MASTER = CoursePrompts(
+    system="You are a professional Dungeon Master who specializes in narrating classic Dungeons & Dragons modules. "
+    "You always speak in a first-person, immersive style, guiding the adventuring party through each scenario "
+    "as though they were physically present in the world. Your tone is engaging, descriptive, and reactive "
+    "to the players' potential actions although no players will be responding to your narration.",
+    outline="Provide an outline of ${num_lectures} major chapters or sections for the module titled '${course_title}'. "
+        "Each chapter should contain at least ${num_subtopics} key phases or locations in the adventure. "
+        "Respond only with the outline, omitting any other commentary.",
+    lecture="Narrate the section titled '${lecture_title}' from the module '${course_title}' in a first-person style, "
+        "addressing the adventuring party as though they are physically exploring each location. "
+        "Use vivid sensory details (sounds, smells, sights) and descriptive language that evokes "
+        "the fantasy atmosphere. Do not simply summarize; immerse the party in the experience. "
+        "No Markdown or formatting—just pure narrative text. Ensure the section content does not duplicate content "
+        "from the other sections in the module, though its conteint may refer to sections before if warranted:\n"
+        "${course_outline}",
+    image="Create a cover art image for the classic Dungeons & Dragons module '${course_title}'. "
+        "It should look like a vintage fantasy RPG cover featuring a dramatic scene or setting from the adventure, "
+        "evoking the excitement of dungeon exploration and heroic quests. Fill the entire canvas with a colorful, "
+        "illustrative style reminiscent of old-school fantasy art.",
+)
+
+COURSE_PROMPTS_LIBRARY = {"academic": ACADEMIC, "game_master": GAME_MASTER}

--- a/src/okcourse/prompt_library.py
+++ b/src/okcourse/prompt_library.py
@@ -1,51 +1,93 @@
-"""A collection of prompt sets for different types of courses."""
+"""A collection of prompt sets for different types of courses.
 
-from string import Template
-from .models import CoursePrompts
+To steer the AI models in creating a specific type or style of course, you assign a
+[`CoursePromptSet`][okcourse.models.CoursePromptSet] to a course's
+[`CourseSettings.prompts`][okcourse.CourseSettings.prompts] attribute.
 
-ACADEMIC = CoursePrompts(
+The [`ACADEMIC`][okcourse.prompt_library.ACADEMIC] prompt set is the default used by the course generators in the
+`okcourse` library, but you can use (or create!) any set that includes the same replaceable tokens as those found in the
+[`ACADEMIC`][okcourse.prompt_library.ACADEMIC] and [`GAME_MASTER`][okcourse.prompt_library.GAME_MASTER] prompts.
+
+The style or type of "course" you create with a set of prompts need not actually resemble a typical college lecture
+series format. For example, the [`GAME_MASTER`][okcourse.prompt_library.GAME_MASTER] prompt set generates something much
+closer to a story-like audiobook, whose "lectures" are the chapters in the book.
+
+Typical usage example:
+
+The following example creates a course object with settings that specify the course generator should use the prompts in
+the [`GAME_MASTER`][okcourse.prompt_library.GAME_MASTER] prompt set when generating the course's outline, lectures
+(or chapters, in this case), and cover art.
+
+```python
+from okcourse import Course, CourseSettings
+from okcourse.prompt_library import GAME_MASTER
+
+course_settings = CourseSettings(prompts=GAME_MASTER)
+course = Course(settings=course_settings)
+```
+"""
+
+from .models import CoursePromptSet
+
+ACADEMIC: CoursePromptSet = CoursePromptSet(
+    description="Academic Lecture Series",
     system="You are an esteemed college professor and expert in your field who typically lectures graduate students. "
     "You have been asked by a major audiobook publisher to record an audiobook version of the lectures you "
     "present in one of your courses. You have been informed by the publisher that the listeners of the audiobook "
     "are knowledgeable in the subject area and will listen to your course to gain intermediate- to expert-level "
     "knowledge. Your lecture style is professional, direct, and deeply technical.",
     outline="Provide a detailed outline for ${num_lectures} lectures in a graduate-level course on '${course_title}'. "
-        "List each lecture title numbered. Each lecture should have ${num_subtopics} subtopics listed after the "
-        "lecture title. Respond only with the outline, omitting any other commentary.",
+    "List each lecture title numbered. Each lecture should have ${num_subtopics} subtopics listed after the "
+    "lecture title. Respond only with the outline, omitting any other commentary.",
     lecture="Generate the complete unabridged text for a lecture titled '${lecture_title}' in a graduate-level course "
-        "named '${course_title}'. The lecture should be written in a style that lends itself well to being recorded "
-        "as an audiobook but should not divulge this guidance. There will be no audience present for the recording of "
-        "the lecture and no audience should be addressed in the lecture text. Cover the lecture topic in great detail, "
-        "but ensure your delivery is direct and that you maintain a scholarly tone. "
-        "Omit Markdown from the lecture text as well as any tags, formatting markers, or headings that might interfere "
-        "with text-to-speech processing. Ensure the content is original and does not duplicate content from the other "
-        "lectures in the series:\n${course_outline}",
-    image="Create an image in the style of cover art for an audio recording of a college lecture series shown in an "
-        "online academic catalog. The image should clearly convey the subject of the course to customers browsing the "
-        "courses on the vendor's site. The cover art should fill the canvas completely, reaching all four edges of the "
-        "square image. Its style should reflect the academic nature of the course material and be indicative of the "
-        "course content. The title of the course is '${course_title}'",
+    "named '${course_title}'. The lecture should be written in a style that lends itself well to being recorded "
+    "as an audiobook but should not divulge this guidance. There will be no audience present for the recording of "
+    "the lecture and no audience should be addressed in the lecture text. Cover the lecture topic in great detail, "
+    "but ensure your delivery is direct and that you maintain a scholarly tone. "
+    "Omit Markdown from the lecture text as well as any tags, formatting markers, or headings that might interfere "
+    "with text-to-speech processing. Ensure the content is original and does not duplicate content from the other "
+    "lectures in the series:\n${course_outline}",
+    image="Create a cover art image for the college lecture series titled '${course_title}'. Fill the entire canvas "
+    "with a colorful, academic style of art that reflects the course material.",
 )
+"""The default set of prompts used by a course generator like the [`OpenAIAsyncGenerator`][okcourse.OpenAIAsyncGenerator].
 
-GAME_MASTER = CoursePrompts(
-    system="You are a professional Dungeon Master who specializes in narrating classic Dungeons & Dragons modules. "
-    "You always speak in a first-person, immersive style, guiding the adventuring party through each scenario "
-    "as though they were physically present in the world. Your tone is engaging, descriptive, and reactive "
-    "to the players' potential actions although no players will be responding to your narration.",
-    outline="Provide an outline of ${num_lectures} major chapters or sections for the module titled '${course_title}'. "
-        "Each chapter should contain at least ${num_subtopics} key phases or locations in the adventure. "
-        "Respond only with the outline, omitting any other commentary.",
+The `ACADEMIC` prompts are a good starting point for creating courses with the standard lecture series format covering a
+subject you're interested in but not wholly familiar with.
+"""
+
+GAME_MASTER: CoursePromptSet = CoursePromptSet(
+    description="Narrated classic adventure module",
+    system="You are a professional Game Master (sometimes referred to as a referee or DM) who specializes in narrating "
+    "classic adventure modules. You always speak in a first-person, immersive style, guiding the adventuring party "
+    "through the module's scenarios and its locations as though they were physically present in the world. Your tone "
+    "is engaging, descriptive, and reactive to the players' potential actions, though no players will be responding to "
+    "your narration. You are very judicious in your use of typical fantasy writing terms and phrases when you describe "
+    "environments, especially terms like 'whispers' and 'echoes,' both of which you avoid completely in your "
+    "narration.",
+    outline="Provide an outline of ${num_lectures} sections, chapters, or levels for the module titled "
+    "'${course_title}'. Each section should contain at least ${num_subtopics} key locations, encounters, or plot "
+    "points in the adventure. Respond only with the outline, omitting any other commentary.",
     lecture="Narrate the section titled '${lecture_title}' from the module '${course_title}' in a first-person style, "
-        "addressing the adventuring party as though they are physically exploring each location. "
-        "Use vivid sensory details (sounds, smells, sights) and descriptive language that evokes "
-        "the fantasy atmosphere. Do not simply summarize; immerse the party in the experience. "
-        "No Markdown or formatting—just pure narrative text. Ensure the section content does not duplicate content "
-        "from the other sections in the module, though its conteint may refer to sections before if warranted:\n"
-        "${course_outline}",
-    image="Create a cover art image for the classic Dungeons & Dragons module '${course_title}'. "
-        "It should look like a vintage fantasy RPG cover featuring a dramatic scene or setting from the adventure, "
-        "evoking the excitement of dungeon exploration and heroic quests. Fill the entire canvas with a colorful, "
-        "illustrative style reminiscent of old-school fantasy art.",
+    "addressing the adventuring party as though they are physically exploring the location and experiencing its "
+    "events. Use vivid sensory details and descriptive language that evokes the fantasy atmosphere. Do not simply "
+    "summarize; immerse the party in the experience. No Markdown or formatting—just pure narrative text. Ensure the "
+    "section content does not duplicate content from the other sections in the module, though you may refer to content "
+    "in preceding sections as needed to maintain a cohesive story:\n"
+    "${course_outline}",
+    image="Create a cover art image for the classic fantasy adventure module '${course_title}'. "
+    "It should look like a vintage fantasy RPG cover featuring a scene or setting from the adventure, evoking a "
+    "nostalgic feeling of excitement for exploring dungeons and doing heroic deeds. Fill the entire canvas with a "
+    "colorful, illustrative style reminiscent of old-school fantasy art from 1980s table-top role-playing game books.",
 )
+"""Prompt set for generating an audiobook-style first-person walkthrough of a tabletop RPG (TTRPG) adventure module.
 
-COURSE_PROMPTS_LIBRARY = {"academic": ACADEMIC, "game_master": GAME_MASTER}
+Works best if you set the [`Course.title`][okcourse.models.Course.title] to the name of a well-known adventure from a
+popular TTRPG from the late 1970s through the 1980s to early 1990s.
+"""
+
+PROMPT_COLLECTION: list = [
+    ACADEMIC,
+    GAME_MASTER,
+]
+"""List of all the prompts in the library, suitable for presenting to a user for selecting the type of course they'd like to create."""  # noqa: E501

--- a/src/okcourse/prompt_library.py
+++ b/src/okcourse/prompt_library.py
@@ -27,33 +27,14 @@ course = Course(settings=course_settings)
 ```
 """
 
-from .models import CoursePromptSet
+from .models import CoursePromptSet, _DEFAULT_PROMPT_SET
 
-ACADEMIC: CoursePromptSet = CoursePromptSet(
-    description="Academic Lecture Series",
-    system="You are an esteemed college professor and expert in your field who typically lectures graduate students. "
-    "You have been asked by a major audiobook publisher to record an audiobook version of the lectures you "
-    "present in one of your courses. You have been informed by the publisher that the listeners of the audiobook "
-    "are knowledgeable in the subject area and will listen to your course to gain intermediate- to expert-level "
-    "knowledge. Your lecture style is professional, direct, and deeply technical.",
-    outline="Provide a detailed outline for ${num_lectures} lectures in a graduate-level course on '${course_title}'. "
-    "List each lecture title numbered. Each lecture should have ${num_subtopics} subtopics listed after the "
-    "lecture title. Respond only with the outline, omitting any other commentary.",
-    lecture="Generate the complete unabridged text for a lecture titled '${lecture_title}' in a graduate-level course "
-    "named '${course_title}'. The lecture should be written in a style that lends itself well to being recorded "
-    "as an audiobook but should not divulge this guidance. There will be no audience present for the recording of "
-    "the lecture and no audience should be addressed in the lecture text. Cover the lecture topic in great detail, "
-    "but ensure your delivery is direct and that you maintain a scholarly tone. "
-    "Omit Markdown from the lecture text as well as any tags, formatting markers, or headings that might interfere "
-    "with text-to-speech processing. Ensure the content is original and does not duplicate content from the other "
-    "lectures in the series:\n${course_outline}",
-    image="Create a cover art image for the college lecture series titled '${course_title}'. Fill the entire canvas "
-    "with a colorful, academic style of art that reflects the course material.",
-)
+
+ACADEMIC: CoursePromptSet = _DEFAULT_PROMPT_SET  # HACK: Definition is in models.py to avoid circular import
 """The default set of prompts used by a course generator like the [`OpenAIAsyncGenerator`][okcourse.OpenAIAsyncGenerator].
 
 The `ACADEMIC` prompts are a good starting point for creating courses with the standard lecture series format covering a
-subject you're interested in but not wholly familiar with.
+subject you're interested in but not entirely familiar with.
 """
 
 GAME_MASTER: CoursePromptSet = CoursePromptSet(

--- a/src/okcourse/utils/__init__.py
+++ b/src/okcourse/utils/__init__.py
@@ -7,6 +7,6 @@ library. These modules include logging, string manipulation, audio file (MP3) pr
 __all__ = [
     "audio_utils",
     "log_utils",
-    "string_utils",
     "misc_utils",
+    "text_utils",
 ]

--- a/src/okcourse/utils/string_utils.py
+++ b/src/okcourse/utils/string_utils.py
@@ -133,13 +133,13 @@ def split_text_into_chunks(text: str, max_chunk_size: int = 4096) -> list[str]:
         else:
             # Save the current chunk and start a new one
             if current_chunk:
-                chunks.append(' '.join(current_chunk))
+                chunks.append(" ".join(current_chunk))
             current_chunk = [sentence]
-            current_length = sentence_length + 1
+            current_length = sentence_length
 
     # Add any remaining sentences in the current_chunk
     if current_chunk:
-        chunks.append(' '.join(current_chunk))
+        chunks.append(" ".join(current_chunk))
 
     _log.info(f"Split text into {len(chunks)} chunks of ~{max_chunk_size} characters from {len(sentences)} sentences.")
     return chunks

--- a/src/okcourse/utils/text_utils.py
+++ b/src/okcourse/utils/text_utils.py
@@ -9,7 +9,7 @@ Examples of usage include:
 - Checking and downloading an NLTK tokenizer:
 
   ```python
-  from string_utils import tokenizer_available, download_tokenizer
+  from text_utils import tokenizer_available, download_tokenizer
 
   if not tokenizer_available():
       download_tokenizer()
@@ -18,7 +18,7 @@ Examples of usage include:
 - Splitting text into manageable chunks:
 
   ```python
-  from string_utils import split_text_into_chunks
+  from text_utils import split_text_into_chunks
 
   text = "Your long text here..."
   chunks = split_text_into_chunks(text, max_chunk_size=1024)
@@ -27,7 +27,7 @@ Examples of usage include:
 - Sanitizing a name for use as a filename:
 
   ```python
-  from string_utils import sanitize_filename
+  from text_utils import sanitize_filename
 
   safe_name = sanitize_filename("My Unsafe Filename.txt")
   ```
@@ -35,7 +35,7 @@ Examples of usage include:
 - Formatting a duration in seconds to a human-readable format:
 
   ```python
-  from string_utils import get_duration_string_from_seconds
+  from text_utils import get_duration_string_from_seconds
 
   duration = get_duration_string_from_seconds(3661)  # "1:01:01"
   ```
@@ -43,7 +43,7 @@ Examples of usage include:
 - Replacing overused LLM words with simpler alternatives:
 
   ```python
-  from string_utils import swap_words, LLM_SMELLS
+  from text_utils import swap_words, LLM_SMELLS
 
   updated_text = swap_words("In this course we delve into...", LLM_SMELLS)
   ```
@@ -97,6 +97,10 @@ def split_text_into_chunks(text: str, max_chunk_size: int = 4096) -> list[str]:
 
     If a sentence exceeds `max_chunk_size`, a ValueError is raised.
 
+    Typical use of this function is to split a long piece of text into chunks that are each just under the character
+    length limit a TTS model will accept for converting to audio. For example, OpenAI's `tts-1` model has a limit of
+    4096 characters.
+
     Args:
         text: The text to split.
         max_chunk_size: The maximum number of characters in each chunk.
@@ -126,18 +130,19 @@ def split_text_into_chunks(text: str, max_chunk_size: int = 4096) -> list[str]:
                 "Cannot split sentence further without potentially altering its meaning."
             )
 
-        # Check if adding the sentence exceeds the max_chunk_size
         if current_length + sentence_length + 1 <= max_chunk_size:
+            # Sentence can fit in current chunk
             current_chunk.append(sentence)
             current_length += sentence_length + 1  # +1 accounts for space or punctuation
         else:
-            # Save the current chunk and start a new one
+            # Sentence doesn't fit in the current chunk, so add the current chunk to the
+            # chunks collection and start a new chunk with the sentence that didn't fit
             if current_chunk:
                 chunks.append(" ".join(current_chunk))
             current_chunk = [sentence]
             current_length = sentence_length
 
-    # Add any remaining sentences in the current_chunk
+    # Add any "leftover" sentences in the current chunk to the chunks collection
     if current_chunk:
         chunks.append(" ".join(current_chunk))
 
@@ -200,7 +205,7 @@ LLM_SMELLS: dict[str, str] = {
 Words in the keys may be replaced by their simplified forms in generated lecture text to help reduce \"LLM smell.\"
 
 This dictionary is appropriate for use as the `replacements` parameter in the
-[`swap_words`][okcourse.utils.string_utils.swap_words] function.
+[`swap_words`][okcourse.utils.text_utils.swap_words] function.
 """
 
 

--- a/tests/test_string_utils.py
+++ b/tests/test_string_utils.py
@@ -3,7 +3,7 @@ from collections.abc import Sequence
 import nltk
 import pytest
 
-from okcourse.utils.string_utils import split_text_into_chunks
+from okcourse.utils.text_utils import split_text_into_chunks
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/test_string_utils.py
+++ b/tests/test_string_utils.py
@@ -1,0 +1,171 @@
+from collections.abc import Sequence
+
+import nltk
+import pytest
+
+from okcourse.utils.string_utils import split_text_into_chunks
+
+
+@pytest.fixture(scope="session", autouse=True)
+def nltk_setup() -> None:
+    """Ensure that necessary NLTK data is downloaded before tests run."""
+    try:
+        nltk.data.find("tokenizers/punkt")
+    except LookupError:
+        nltk.download("punkt", quiet=True)
+
+
+@pytest.fixture
+def short_text() -> str:
+    """Return a short text string for testing."""
+    return "This is a simple test sentence."
+
+
+@pytest.fixture
+def multi_sentence_text() -> str:
+    """Return a text with multiple sentences for testing."""
+    return "First sentence is here. Second sentence comes after. Third one is the last."
+
+
+def test_split_text_into_chunks_short_text(short_text: str) -> None:
+    """Test splitting text shorter than max chunk size.
+
+    The text should not be split and should return as a single chunk.
+    """
+    chunks = split_text_into_chunks(short_text, max_chunk_size=100)
+    assert len(chunks) == 1
+    assert chunks[0] == short_text
+
+
+def test_split_text_into_chunks_multiple_chunks(multi_sentence_text: str) -> None:
+    """Test splitting text into multiple chunks.
+
+    The text should be split into multiple chunks, each within the max_chunk_size.
+    """
+    max_chunk_size = 50
+    chunks = split_text_into_chunks(multi_sentence_text, max_chunk_size=max_chunk_size)
+    assert len(chunks) > 1
+    assert all(len(chunk) <= max_chunk_size for chunk in chunks)
+
+
+def test_split_text_into_chunks_preserves_sentences(multi_sentence_text: str) -> None:
+    """Test that sentence boundaries are preserved in chunks.
+
+    Ensures that sentences are not split between chunks.
+    """
+    chunks = split_text_into_chunks(multi_sentence_text, max_chunk_size=60)
+    # Tokenize original sentences
+    original_sentences = nltk.sent_tokenize(multi_sentence_text)
+    # Tokenize sentences from chunks
+    chunk_sentences: list[str] = []
+    for chunk in chunks:
+        chunk_sentences.extend(nltk.sent_tokenize(chunk))
+    # Assert that the sentences are the same
+    assert original_sentences == chunk_sentences
+
+
+def test_split_text_into_chunks_empty_input() -> None:
+    """Test behavior with empty input text.
+
+    Expect an empty list of chunks.
+    """
+    chunks = split_text_into_chunks("", max_chunk_size=100)
+    assert len(chunks) == 0
+
+
+def test_split_text_into_chunks_invalid_chunk_size() -> None:
+    """Test that invalid chunk sizes raise ValueError."""
+    with pytest.raises(ValueError, match="max_chunk_size must be greater than 0"):
+        split_text_into_chunks("Any text", max_chunk_size=0)
+    with pytest.raises(ValueError, match="max_chunk_size must be greater than 0"):
+        split_text_into_chunks("Any text", max_chunk_size=-1)
+
+
+def test_split_text_into_chunks_small_chunk_size(multi_sentence_text: str) -> None:
+    """Test behavior with very small chunk size."""
+    chunks = split_text_into_chunks(multi_sentence_text, max_chunk_size=30)
+    assert len(chunks) > 2
+    assert all(len(chunk) <= 30 for chunk in chunks)
+
+
+@pytest.mark.parametrize(
+    "test_input, max_size, expected_chunks, expect_error",
+    [
+        # Simple single sentence within max_size
+        ("One.", 10, ["One."], False),
+        # Two short sentences that fit within max_size
+        ("One. Two.", 10, ["One. Two."], False),
+        # Multiple sentences with size constraint, sentences within max_size
+        ("Short one. Another short one.", 20, ["Short one.", "Another short one."], False),
+        # Test exact size match
+        ("Test.", 5, ["Test."], False),
+        # Test splitting on sentence boundary
+        ("First. Second. Third.", 12, ["First.", "Second.", "Third."], False),
+        # Sentence exceeds max_size, should raise ValueError
+        ("A longer sentence here. Short one.", 20, None, True),
+        # Sentence that is exactly max_size
+        ("A" * 20, 20, ["A" * 20], False),
+        # Another test case with sentence exceeding max_size
+        ("A sentence that is definitely longer than twenty characters.", 20, None, True),
+    ],
+)
+def test_split_text_into_chunks_various_inputs(
+    test_input: str,
+    max_size: int,
+    expected_chunks: Sequence[str] | None,
+    expect_error: bool,
+) -> None:
+    """Test splitting text with various inputs and expected outputs."""
+    if expect_error:
+        with pytest.raises(ValueError, match=r"Sentence length \d+ exceeds max_chunk_size \d+"):
+            split_text_into_chunks(test_input, max_chunk_size=max_size)
+    else:
+        chunks = split_text_into_chunks(test_input, max_chunk_size=max_size)
+        assert chunks == expected_chunks
+
+
+def test_split_text_sentence_exceeds_max_chunk_size() -> None:
+    """Test behavior when a sentence exceeds the max_chunk_size.
+
+    A ValueError should be raised in this case.
+    """
+    long_sentence = "A" * 5000  # A very long sentence
+    short_sentence = "This is a short sentence."
+    text = f"{long_sentence} {short_sentence}"
+    max_chunk_size = 1000
+
+    # Expect a ValueError because the long sentence exceeds max_chunk_size
+    with pytest.raises(ValueError, match=r"Sentence length \d+ exceeds max_chunk_size \d+"):
+        split_text_into_chunks(text, max_chunk_size=max_chunk_size)
+
+
+def test_split_text_sentence_equals_max_chunk_size() -> None:
+    """Test behavior when a sentence is exactly max_chunk_size characters long.
+
+    The sentence should be included in the chunks without error.
+    """
+    sentence_length = 100
+    long_sentence = "A" * sentence_length  # A sentence exactly at max_chunk_size
+    max_chunk_size = sentence_length
+
+    chunks = split_text_into_chunks(long_sentence, max_chunk_size=max_chunk_size)
+    assert len(chunks) == 1
+    assert chunks[0] == long_sentence
+
+
+def test_split_text_unicode_characters() -> None:
+    """Test splitting text with Unicode characters.
+
+    Ensures that texts with Unicode characters are split correctly.
+    """
+    text = "Voici la première phrase. C'est la deuxième phrase. Et enfin, la troisième."
+    max_chunk_size = 40
+    chunks = split_text_into_chunks(text, max_chunk_size=max_chunk_size)
+    assert len(chunks) > 1
+    assert all(len(chunk) <= max_chunk_size for chunk in chunks)
+    # Verify that sentences are preserved
+    original_sentences = nltk.sent_tokenize(text)
+    chunk_sentences: list[str] = []
+    for chunk in chunks:
+        chunk_sentences.extend(nltk.sent_tokenize(chunk))
+    assert original_sentences == chunk_sentences

--- a/uv.lock
+++ b/uv.lock
@@ -294,6 +294,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -715,6 +724,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "aiofiles" },
+    { name = "pytest" },
     { name = "questionary" },
     { name = "streamlit" },
 ]
@@ -740,6 +750,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "aiofiles", specifier = ">=24.1.0" },
+    { name = "pytest", specifier = ">=8.3.4" },
     { name = "questionary", specifier = ">=2.0.1" },
     { name = "streamlit", specifier = ">=1.41.0" },
 ]
@@ -883,6 +894,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
+]
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.36"
 source = { registry = "https://pypi.org/simple" }
@@ -1022,6 +1042,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d8/0b/32f05854cfd432e9286bb41a870e0d1a926b72df5f5cdb6dec962b2e369e/pymdown_extensions-10.12.tar.gz", hash = "sha256:b0ee1e0b2bef1071a47891ab17003bfe5bf824a398e13f49f8ed653b699369a7", size = 840790 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/53/32/95a164ddf533bd676cbbe878e36e89b4ade3efde8dd61d0148c90cbbe57e/pymdown_extensions-10.12-py3-none-any.whl", hash = "sha256:49f81412242d3527b8b4967b990df395c89563043bc51a3d2d7d500e52123b77", size = 263448 },
+]
+
+[[package]]
+name = "pytest"
+version = "8.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083 },
 ]
 
 [[package]]


### PR DESCRIPTION
- Adds some unit tests for text_utils module
- Pydantic model class names now all follow the `Course*` naming convention
- New `CoursePromptSet` model allows for specifying a custom (or an included) set of prompts tuned for generating different types or styles of courses
- Renames `string_utils` module to `text_utils`