### PR TITLE
new module `openai_utils.py` + split outline/lecture token counts 

### DIFF
--- a/examples/cli_example_async.py
+++ b/examples/cli_example_async.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import questionary
 
 from okcourse import Course, OpenAIAsyncGenerator
+from okcourse.generators.openai.openai_utils import tts_voices, get_usable_models_async
 from okcourse.utils.text_utils import sanitize_filename, get_duration_string_from_seconds
 
 
@@ -73,6 +74,15 @@ async def main():
             continue  # Input is invalid
         break  # Input is valid - exit loop
 
+    models = await get_usable_models_async()
+    models.text_models.sort()
+    course.settings.text_model_lecture = await async_prompt(
+            questionary.select,
+            "Choose a model to generate the course outline and lectures",
+            choices=models.text_models,
+            default=models.text_models[-1],
+        )
+
     do_generate_audio = False
     do_generate_image = False
     if await async_prompt(questionary.confirm, "Generate MP3 audio file for course?"):
@@ -80,8 +90,8 @@ async def main():
         course.settings.tts_voice = await async_prompt(
             questionary.select,
             "Choose a voice for the course lecturer",
-            choices=generator.tts_voices,
-            default=generator.tts_voices[0],
+            choices=tts_voices,
+            default=tts_voices[0],
         )
 
         if await async_prompt(questionary.confirm, "Generate cover image for audio file?"):

--- a/examples/cost_estimator.py
+++ b/examples/cost_estimator.py
@@ -1,6 +1,10 @@
 """For a given course JSON file, prints the estimated cost of generating a course using OpenAI's pricing."""
 
 from pathlib import Path
+import click
+from rich.console import Console
+from rich.table import Table
+
 from okcourse.models import Course, CourseGenerationInfo
 
 
@@ -8,53 +12,73 @@ class OpenAIPricing:
     """OpenAI's API usage prices.
 
     !!! warning
-        Use these for cost estimation purposes *only*. These prices are determined by OpenAI and are subject to change
-        without notice. For current pricing information, see
-        [Pricing on OpenAI's website](https://openai.com/api/pricing/).
+        Use these for cost estimation purposes *only*.
+        These prices are determined by OpenAI and are subject to change without notice.
+        For current pricing information, see [OpenAI's 'Pricing' page](https://openai.com/api/pricing/).
     """
 
-    GPT4O_INPUT_COST_PER_1K_TOKENS = 0.00250
-    GPT4O_OUTPUT_COST_PER_1K_TOKENS = 0.01000
-    TTS_COST_PER_1K_CHARACTERS = 0.015
-    DALLE_COST_PER_IMAGE = 0.040
+    TEXT_MODEL_INPUT_COST_PER_1K_TOKENS = 0.0150  # o1-preview-2024-09-12 as of 2024-01-17
+    TEXT_MODEL_OUTPUT_COST_PER_1K_TOKENS = 0.0600  # o1-preview-2024-09-12 as of 2024-01-17
+    TTS_MODEL_COST_PER_1K_CHARACTERS = 0.015
+    IMAGE_MODEL_COST_PER_IMAGE = 0.040
 
 
 def calculate_openai_cost(details: CourseGenerationInfo) -> dict[str, float]:
     """Calculates the costs based on token and character counts using the OpenAI pricing.
 
     Args:
-        details (CourseGenerationDetails): The course generation details containing usage data.
+        details (CourseGenerationInfo): The course generation details containing usage data.
 
     Returns:
         dict[str, float]: A dictionary with cost breakdown and total cost.
     """
-    input_token_cost = (details.input_token_count / 1000) * OpenAIPricing.GPT4O_INPUT_COST_PER_1K_TOKENS
-    output_token_cost = (details.output_token_count / 1000) * OpenAIPricing.GPT4O_OUTPUT_COST_PER_1K_TOKENS
-    tts_cost = (details.tts_character_count / 1000) * OpenAIPricing.TTS_COST_PER_1K_CHARACTERS
-    image_cost = details.num_images_generated * OpenAIPricing.DALLE_COST_PER_IMAGE
+    input_token_cost = (details.input_token_count / 1000) * OpenAIPricing.TEXT_MODEL_INPUT_COST_PER_1K_TOKENS
+    output_token_cost = (details.output_token_count / 1000) * OpenAIPricing.TEXT_MODEL_OUTPUT_COST_PER_1K_TOKENS
+    tts_cost = (details.tts_character_count / 1000) * OpenAIPricing.TTS_MODEL_COST_PER_1K_CHARACTERS
+    image_cost = details.num_images_generated * OpenAIPricing.IMAGE_MODEL_COST_PER_IMAGE
 
     total_cost = input_token_cost + output_token_cost + tts_cost + image_cost
 
     return {
-        "input_token_cost ": round(input_token_cost, 2),
-        "output_token_cost": round(output_token_cost, 2),
-        "tts_cost         ": round(tts_cost, 2),
-        "image_cost       ": round(image_cost, 2),
-        "            TOTAL": round(total_cost, 2),
+        "Input token cost": round(input_token_cost, 2),
+        "Output token cost": round(output_token_cost, 2),
+        "TTS cost": round(tts_cost, 2),
+        "Image cost": round(image_cost, 2),
+        "TOTAL": round(total_cost, 2),
     }
 
 
-def main():
-    # Load the course from a file
-    json_file_path = input("Enter the path to the course JSON file: ")
-    json_file = Path(json_file_path).expanduser().resolve()
-    course_json = json_file.read_text()
-    course = Course.model_validate_json(course_json)
+@click.command()
+@click.argument("json_file", type=click.Path(exists=True, file_okay=True, path_type=Path))
+def main(json_file: Path):
+    """Estimate the cost of generating a course using OpenAI's pricing.
 
+    \b
+    Arguments:
+        JSON_FILE: Path to the course JSON file.
+    """
+    console = Console()
+
+    # Load and validate the course JSON
+    try:
+        course_json = json_file.read_text()
+        course = Course.model_validate_json(course_json)
+    except Exception as e:
+        console.print(f"[bold red]Error reading or validating JSON file:[/bold red] {e}")
+        return
+
+    # Calculate cost details
     cost_details_dict = calculate_openai_cost(course.generation_info)
-    print("Estimated cost of generation:")
+
+    # Display the results using a Rich table
+    table = Table(title="Estimated OpenAI Generation Cost", title_style="bold green")
+    table.add_column("Cost component", justify="left", style="cyan", no_wrap=True)
+    table.add_column("Cost (USD)", justify="right", style="magenta")
+
     for k, v in cost_details_dict.items():
-        print(f"  {k}: ${v}")
+        table.add_row(k, f"${v:.2f}", style="bold" if k == "TOTAL" else "")
+
+    console.print(table)
 
 
 if __name__ == "__main__":

--- a/examples/cost_estimator.py
+++ b/examples/cost_estimator.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import click
 from rich.console import Console
 from rich.table import Table
-
 from okcourse.models import Course, CourseGenerationInfo
 
 
@@ -17,8 +16,10 @@ class OpenAIPricing:
         For current pricing information, see [OpenAI's 'Pricing' page](https://openai.com/api/pricing/).
     """
 
-    TEXT_MODEL_INPUT_COST_PER_1K_TOKENS = 0.0150  # o1-preview-2024-09-12 as of 2024-01-17
-    TEXT_MODEL_OUTPUT_COST_PER_1K_TOKENS = 0.0600  # o1-preview-2024-09-12 as of 2024-01-17
+    OUTLINE_INPUT_COST_PER_1K_TOKENS = 0.0025  # Cost for input tokens for course outline
+    OUTLINE_OUTPUT_COST_PER_1K_TOKENS = 0.0100  # Cost for output tokens for course outline
+    LECTURE_INPUT_COST_PER_1K_TOKENS = 0.0150  # Cost for input tokens for course lectures
+    LECTURE_OUTPUT_COST_PER_1K_TOKENS = 0.0600  # Cost for output tokens for course lectures
     TTS_MODEL_COST_PER_1K_CHARACTERS = 0.015
     IMAGE_MODEL_COST_PER_IMAGE = 0.040
 
@@ -32,16 +33,28 @@ def calculate_openai_cost(details: CourseGenerationInfo) -> dict[str, float]:
     Returns:
         dict[str, float]: A dictionary with cost breakdown and total cost.
     """
-    input_token_cost = (details.input_token_count / 1000) * OpenAIPricing.TEXT_MODEL_INPUT_COST_PER_1K_TOKENS
-    output_token_cost = (details.output_token_count / 1000) * OpenAIPricing.TEXT_MODEL_OUTPUT_COST_PER_1K_TOKENS
+    # Costs for course outline
+    outline_input_cost = (details.outline_input_token_count / 1000) * OpenAIPricing.OUTLINE_INPUT_COST_PER_1K_TOKENS
+    outline_output_cost = (details.outline_output_token_count / 1000) * OpenAIPricing.OUTLINE_OUTPUT_COST_PER_1K_TOKENS
+
+    # Costs for course lecture
+    lecture_input_cost = (details.lecture_input_token_count / 1000) * OpenAIPricing.LECTURE_INPUT_COST_PER_1K_TOKENS
+    lecture_output_cost = (details.lecture_output_token_count / 1000) * OpenAIPricing.LECTURE_OUTPUT_COST_PER_1K_TOKENS
+
+    # Other costs (TTS and images)
     tts_cost = (details.tts_character_count / 1000) * OpenAIPricing.TTS_MODEL_COST_PER_1K_CHARACTERS
     image_cost = details.num_images_generated * OpenAIPricing.IMAGE_MODEL_COST_PER_IMAGE
 
-    total_cost = input_token_cost + output_token_cost + tts_cost + image_cost
+    # Total cost
+    total_cost = (
+        outline_input_cost + outline_output_cost + lecture_input_cost + lecture_output_cost + tts_cost + image_cost
+    )
 
     return {
-        "Input token cost": round(input_token_cost, 2),
-        "Output token cost": round(output_token_cost, 2),
+        "Outline input token cost": round(outline_input_cost, 2),
+        "Outline output token cost": round(outline_output_cost, 2),
+        "Lecture input token cost": round(lecture_input_cost, 2),
+        "Lecture output token cost": round(lecture_output_cost, 2),
         "TTS cost": round(tts_cost, 2),
         "Image cost": round(image_cost, 2),
         "TOTAL": round(total_cost, 2),

--- a/examples/streamlit_example.py
+++ b/examples/streamlit_example.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import streamlit as st
 
 from okcourse import Course, OpenAIAsyncGenerator
+from okcourse.generators.openai.openai_utils import tts_voices
 from okcourse.constants import MAX_LECTURES
 from okcourse.prompt_library import PROMPT_COLLECTION
 from okcourse.utils.log_utils import get_logger
@@ -29,9 +30,7 @@ async def main():
     course = st.session_state.course
 
     # Dynamically generate prompt selection options
-    prompt_options = {
-        prompt.description.replace("_", " ").capitalize(): prompt for prompt in PROMPT_COLLECTION
-    }
+    prompt_options = {prompt.description: prompt for prompt in PROMPT_COLLECTION}
     selected_prompt_name = st.selectbox("Select the course prompt style:", options=list(prompt_options.keys()))
     selected_prompt = prompt_options[selected_prompt_name]
     course.settings.prompts = selected_prompt
@@ -53,7 +52,7 @@ async def main():
     generator = OpenAIAsyncGenerator(course)
 
     if generate_audio:
-        course.settings.tts_voice = st.selectbox("Choose a voice for the course lecturer", options=generator.tts_voices)
+        course.settings.tts_voice = st.selectbox("Choose a voice for the course lecturer", options=tts_voices)
 
     course.settings.output_directory = (
         Path(st.text_input("Output directory:", value=course.settings.output_directory)).expanduser().resolve()

--- a/src/okcourse/generators/openai/__init__.py
+++ b/src/okcourse/generators/openai/__init__.py
@@ -2,8 +2,12 @@
 
 from .async_openai import OpenAIAsyncGenerator
 # from .sync_openai import OpenAISyncGenerator  # NOT YET IMPLEMENTED
+from okcourse.generators.openai.openai_utils import AIModels, get_usable_models_sync, get_usable_models_async
 
 __all__ = [
     "OpenAIAsyncGenerator",
     # "OpenAISyncGenerator"  # NOT YET IMPLEMENTED
+    "AIModels",
+    "get_usable_models_async",
+    "get_usable_models_sync",
 ]

--- a/src/okcourse/generators/openai/async_openai.py
+++ b/src/okcourse/generators/openai/async_openai.py
@@ -96,8 +96,8 @@ class OpenAIAsyncGenerator(CourseGenerator):
         self.log.info(f"Received outline for course '{course.title}'...")
 
         if outline_completion.usage:
-            course.generation_info.input_token_count += outline_completion.usage.prompt_tokens
-            course.generation_info.output_token_count += outline_completion.usage.completion_tokens
+            course.generation_info.outline_input_token_count += outline_completion.usage.prompt_tokens
+            course.generation_info.outline_output_token_count += outline_completion.usage.completion_tokens
         generated_outline = outline_completion.choices[0].message.parsed
 
         # Reset the topic to what was passed in if the LLM modified the original (it sometimes adds its own subtitle)
@@ -154,8 +154,8 @@ class OpenAIAsyncGenerator(CourseGenerator):
             max_completion_tokens=15000,
         )
         if response.usage:
-            course.generation_info.input_token_count += response.usage.prompt_tokens
-            course.generation_info.output_token_count += response.usage.completion_tokens
+            course.generation_info.lecture_input_token_count += response.usage.prompt_tokens
+            course.generation_info.lecture_output_token_count += response.usage.completion_tokens
         lecture_text = response.choices[0].message.content.strip()
         lecture_text = swap_words(lecture_text, LLM_SMELLS)
 

--- a/src/okcourse/generators/openai/openai_utils.py
+++ b/src/okcourse/generators/openai/openai_utils.py
@@ -1,0 +1,108 @@
+"""Shared utilities for interacting with the OpenAI API."""
+
+import asyncio
+from dataclasses import dataclass
+from typing import Optional
+
+from openai import AsyncOpenAI
+
+from openai.types.audio.speech_create_params import SpeechCreateParams
+from openai.types.audio.speech_model import SpeechModel
+from openai.types.chat_model import ChatModel
+from openai.types.image_model import ImageModel
+from openai.types import Model
+
+from okcourse.utils.log_utils import get_logger
+from okcourse.utils.misc_utils import extract_literal_values_from_member, extract_literal_values_from_type
+
+
+client = AsyncOpenAI()
+
+_log = get_logger(__name__)
+
+tts_voices: list[str] = extract_literal_values_from_member(SpeechCreateParams, "voice")
+
+
+@dataclass
+class AIModels:
+    image_models: list[str]
+    speech_models: list[str]
+    text_models: list[str]
+    other_models: list[str] | None
+
+
+def get_library_models() -> AIModels:
+    """Gets all the models known to the OpenAI Python library.
+
+    These are *all* the available models the OpenAI library knows about, which might include models not available for
+    use by the client's API key. Not included are any custom models (typically fine-tuned models) in the account
+    represented by the API key.
+
+    Returns:
+        AIModels: All models known to the OpenAI Python library. Excludes custom (user-created) models.
+    """
+
+    return AIModels(
+        image_models=extract_literal_values_from_type(ImageModel),
+        speech_models=extract_literal_values_from_type(SpeechModel),
+        text_models=extract_literal_values_from_type(ChatModel),
+    )
+
+
+async def _get_usable_models() -> AIModels:
+    """Gets the models available for use from the OpenAI API for the API key in use by the client.
+
+    Returns:
+        AIModels: _description_
+    """
+
+    # Initialize lists to store the categorized model IDs
+    image_models: list[str] = []
+    text_models: list[str] = []
+    speech_models: list[str] = []
+    custom_models: list[str] = []
+
+    all_models = get_library_models()
+
+    try:
+        _log.info("Fetching list of models available for use by current API key...")
+        models_data: list[Model] = await client.models.list().data
+        _log.info(f"Got {len(models_data)} models from OpenAI API.")
+    except Exception as e:
+        _log.error(f"Failed to fetch models: {e}")
+        return AIModels([], [], [], [])
+
+    # Categorize models based on the extracted literals
+    for model in models_data:
+        if model.id in all_models.text_models:
+            text_models.append(model.id)
+        elif model.id in all_models.image_models:
+            image_models.append(model.id)
+        elif model.id in all_models.speech_models:
+            speech_models.append(model.id)
+        else:
+            custom_models.append(model.id)
+
+    return AIModels(
+        image_models=image_models,
+        text_models=text_models,
+        speech_models=speech_models,
+        other_models=custom_models,
+    )
+
+
+# Cache the available models to avoid redundant API calls
+_usable_models: Optional[AIModels] = None
+
+
+async def get_usable_models_async() -> AIModels:
+    """Asynchronously get the usable models, fetching them if not already cached."""
+    global _usable_models
+    if _usable_models is None:
+        _usable_models = await _get_usable_models()
+    return _usable_models
+
+
+def get_usable_models_sync() -> AIModels:
+    """Synchronously get the usable models using asyncio.run()."""
+    return asyncio.run(get_usable_models_async())

--- a/src/okcourse/models.py
+++ b/src/okcourse/models.py
@@ -155,25 +155,41 @@ class CourseSettings(BaseModel):
 
 
 class CourseGenerationInfo(BaseModel):
-    """Details about the course generation, including okcourse version, tokent counts (input and output), and durations."""  # noqa: E501
+    """Details about the course generation, including okcourse version, token counts (input and output), and durations.
 
-    generator_type: str | None = Field(
-        None,
-        description="The type of course generator used to generate the course content.",
-    )
+    You can estimate the cost of course generation based on the token count values in this class and the models that
+    were used to produce them. The model names are specified in the [`CourseSettings`][okcourse.CourseSettings] and most
+    AI service providers make cost-per-token pricing available on their website, which may vary by provider and your
+    account or subscription level.
+    """
+
     okcourse_version: str | None = Field(
         None,
         description="The version of the okcourse library used to generate the course.",
     )
-    input_token_count: int = Field(
-        0,
-        description="The total number of tokens sent to the text completion endpoint when requesting content "
-        "generation. This count includes the tokens sent in the outline and lecture prompts.",
+    generator_type: str | None = Field(
+        None,
+        description="The type of course generator used to generate the course content.",
     )
-    output_token_count: int = Field(
+    lecture_input_token_count: int = Field(
         0,
-        description="The total number of tokens returned by the text completion endpoint. Includes tokens return for "
-        "all outline and lecture content generated.",
+        description="The total number of tokens sent to the text completion endpoint when requesting the lecture "
+        "content for the course. This count does NOT include the tokens sent when requesting the outline.",
+    )
+    lecture_output_token_count: int = Field(
+        0,
+        description="The total number of tokens returned by the text completion endpoint is response to lecture "
+        "generation request for the course. This count does NOT include the tokens returned for outline requests.",
+    )
+    outline_input_token_count: int = Field(
+        0,
+        description="The total number of tokens sent to the text completion endpoint when requesting the outline(s) "
+        "for the course. This count does NOT include the tokens sent when requesting the course's lecture content.",
+    )
+    outline_output_token_count: int = Field(
+        0,
+        description="The total number of tokens returned by the text completion endpoint is response to outline "
+        "generation requests for the course. This count does NOT include the tokens returned for lecture requests.",
     )
     tts_character_count: int = Field(
         0,

--- a/src/okcourse/models.py
+++ b/src/okcourse/models.py
@@ -69,7 +69,7 @@ class CoursePromptSet(BaseModel):
 
 
 _DEFAULT_PROMPT_SET = CoursePromptSet(
-    description="Academic Lecture Series",
+    description="Academic lecture series",
     system="You are an esteemed college professor and expert in your field who typically lectures graduate students. "
     "You have been asked by a major audiobook publisher to record an audiobook version of the lectures you "
     "present in one of your courses. You have been informed by the publisher that the listeners of the audiobook "

--- a/src/okcourse/prompt_library.py
+++ b/src/okcourse/prompt_library.py
@@ -44,22 +44,22 @@ GAME_MASTER: CoursePromptSet = CoursePromptSet(
     "through the module's scenarios and its locations as though they were physically present in the world. Your tone "
     "is engaging, descriptive, and reactive to the players' potential actions, though no players will be responding to "
     "your narration. You are very judicious in your use of typical fantasy writing terms and phrases when you describe "
-    "environments, especially terms like 'whispers' and 'echoes,' both of which you avoid completely in your "
-    "narration.",
+    "environments, especially terms like 'whispers' and 'echoes,' neither of which you include in your narrations.",
     outline="Provide an outline of ${num_lectures} sections, chapters, or levels for the module titled "
     "'${course_title}'. Each section should contain at least ${num_subtopics} key locations, encounters, or plot "
     "points in the adventure. Respond only with the outline, omitting any other commentary.",
     lecture="Narrate the section titled '${lecture_title}' from the module '${course_title}' in a first-person style, "
     "addressing the adventuring party as though they are physically exploring the location and experiencing its "
-    "events. Use vivid sensory details and descriptive language that evokes the fantasy atmosphere. Do not simply "
-    "summarize; immerse the party in the experience. No Markdown or formatting—just pure narrative text. Ensure the "
-    "section content does not duplicate content from the other sections in the module, though you may refer to content "
-    "in preceding sections as needed to maintain a cohesive story:\n"
+    "events. Be as faithful to the original module as possible, using its content as the source of your narration. "
+    "Use vivid sensory details and descriptive language that evokes the fantasy atmosphere. Do not simply summarize; "
+    "immerse the party in the experience. No Markdown or formatting—just pure narrative text. Ensure the section "
+    "content does not duplicate content from the other sections in the module, though you may refer to content in "
+    "preceding sections as needed to maintain a cohesive story:\n"
     "${course_outline}",
     image="Create a cover art image for the classic fantasy adventure module '${course_title}'. "
     "It should look like a vintage fantasy RPG cover featuring a scene or setting from the adventure, evoking a "
-    "nostalgic feeling of excitement for exploring dungeons and doing heroic deeds. Fill the entire canvas with a "
-    "colorful, illustrative style reminiscent of old-school fantasy art from 1980s table-top role-playing game books.",
+    "nostalgic feeling of excitement for exploring dungeons and doing heroic deeds. Fill the entire canvas with an "
+    "illustrative style and colors reminiscent of old-school fantasy art from a 1980s tabletop role-playing game.",
 )
 """Prompt set for generating an audiobook-style first-person walkthrough of a tabletop RPG (TTRPG) adventure module.
 


### PR DESCRIPTION
- Updates `CourseGenerationDetails` and recording of API usage data (num tokens) separately for outlines and lectures since you can now use a different model for each
- Starts the move of some stuff to `openai_utils.py` (in prep for adding a sync generator and but also for general code hygiene)
- New functionality in `openai_utils.py` includes getting a list of all the models from the API and then pruning the list to only those you (your API key) has access to, then grouping and bundling the groups into a new `AIModels` class you can use to provide model choices in UI
- Updated the `cli_example_async.py` and `cost_estimator.py` example scripts to handle all the above.

Example `cost_estimator.py` output:

```console
user@host ~% uv run examples/cost_estimator.py /Users/user/.okcourse_o1/dissecting_chicxulub_approach_entry_impact_affect_and_recovery.json
     Estimated OpenAI Generation Cost     
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
┃ Cost component            ┃ Cost (USD) ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
│ Outline input token cost  │      $0.00 │
│ Outline output token cost │      $0.01 │
│ Lecture input token cost  │      $0.40 │
│ Lecture output token cost │      $2.63 │
│ TTS cost                  │      $2.20 │
│ Image cost                │      $0.04 │
│ TOTAL                     │      $5.27 │
└───────────────────────────┴────────────┘
```

### NOT in this PR:

- [ ] TODO: Unit tests for all the above. 😳
- [ ] TODO: Update Streamlit example to handle all of the above
- [ ] TODO: Detect and handle generation denials more gracefully than just moving ahead with a lecture that consists of only something like _"I'm sorry, I can't generate that content."_ Encountered that while using the `GAME_MASTER` prompt set to generate a first-person walkthrough of an AD&D 1e module. Unsurprising, I suppose; just need to handle it better than rolling with an empty "lecture."