### PR TITLE
Add minimal unit tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,3 @@
 [pytest]
 addopts = --tb=short
 testpaths = tests
-plugins = uv

--- a/tests/test_audio_utils.py
+++ b/tests/test_audio_utils.py
@@ -1,0 +1,49 @@
+"""Unit tests for okcourse audio utility functions."""
+
+import io
+import pytest
+
+from okcourse.utils.audio_utils import _is_valid_mp3, combine_mp3_buffers
+
+
+def test_is_valid_mp3_with_id3_header():
+    """Test _is_valid_mp3 with ID3 header."""
+    mp3_data_id3 = b"ID3\x03\x00\x00\x00\x00\x00\x00"  # Mock ID3 header
+    assert _is_valid_mp3(mp3_data_id3) is True
+
+
+def test_is_valid_mp3_with_frame_sync():
+    """Test _is_valid_mp3 with frame sync pattern."""
+    mp3_data_sync = b"\xff\xfb\x90\x00"  # Mock MP3 frame sync
+    assert _is_valid_mp3(mp3_data_sync) is True
+
+
+def test_is_valid_mp3_with_invalid_data():
+    """Test _is_valid_mp3 with invalid data."""
+    invalid_data = b"This is not MP3 data"
+    assert _is_valid_mp3(invalid_data) is False
+
+
+def test_is_valid_mp3_with_empty_data():
+    """Test _is_valid_mp3 with empty data."""
+    empty_data = b""
+    assert _is_valid_mp3(empty_data) is False
+
+
+def test_combine_mp3_buffers_empty_list():
+    """Test combine_mp3_buffers with empty buffer list raises ValueError."""
+    with pytest.raises(ValueError, match="No MP3 buffers provided"):
+        combine_mp3_buffers([])
+
+
+def test_combine_mp3_buffers_invalid_mp3():
+    """Test combine_mp3_buffers with invalid MP3 data raises ValueError."""
+    invalid_buffer = io.BytesIO(b"Not MP3 data")
+    with pytest.raises(ValueError, match="Invalid MP3 buffer"):
+        combine_mp3_buffers([invalid_buffer])
+
+
+# Note: Testing the full combine_mp3_buffers function would require actual MP3 data
+# and the mutagen library to work with real MP3 files. For a minimal test suite,
+# we're focusing on the edge cases and validation logic that can be tested
+# without requiring actual audio files.

--- a/tests/test_misc_utils.py
+++ b/tests/test_misc_utils.py
@@ -1,0 +1,88 @@
+"""Unit tests for okcourse misc utility functions."""
+
+import pytest
+from typing import Literal, Union, Optional
+
+from okcourse.utils.misc_utils import (
+    extract_literal_values_from_type,
+    extract_literal_values_from_member
+)
+
+
+def test_extract_literal_values_from_simple_literal():
+    """Test extracting values from a simple Literal type."""
+    Voice = Literal["alloy", "echo", "fable"]
+    values = extract_literal_values_from_type(Voice)
+    assert sorted(values) == ["alloy", "echo", "fable"]
+
+
+def test_extract_literal_values_from_union_with_literal():
+    """Test extracting values from a Union containing Literal."""
+    VoiceOrNone = Union[Literal["voice1", "voice2"], None]
+    values = extract_literal_values_from_type(VoiceOrNone)
+    assert sorted(values) == ["voice1", "voice2"]
+
+
+def test_extract_literal_values_from_optional_literal():
+    """Test extracting values from Optional[Literal[...]]."""
+    OptionalVoice = Optional[Literal["option1", "option2"]]
+    values = extract_literal_values_from_type(OptionalVoice)
+    assert sorted(values) == ["option1", "option2"]
+
+
+def test_extract_literal_values_from_nested_union():
+    """Test extracting values from nested Union with multiple Literals."""
+    ComplexType = Union[Literal["a", "b"], Literal["c", "d"], str]
+    values = extract_literal_values_from_type(ComplexType)
+    assert sorted(values) == ["a", "b", "c", "d"]
+
+
+def test_extract_literal_values_from_non_literal_raises_error():
+    """Test that extracting from non-Literal type raises TypeError."""
+    with pytest.raises(TypeError, match="No Literal values found"):
+        extract_literal_values_from_type(str)
+
+
+def test_extract_literal_values_from_member():
+    """Test extracting literal values from a class member."""
+    class TestClass:
+        voice: Literal["alloy", "echo", "fable"]
+        model: str
+    
+    values = extract_literal_values_from_member(TestClass, "voice")
+    assert sorted(values) == ["alloy", "echo", "fable"]
+
+
+def test_extract_literal_values_from_member_with_union():
+    """Test extracting literal values from a class member with Union."""
+    class TestClass:
+        voice: Union[Literal["voice1", "voice2"], None]
+    
+    values = extract_literal_values_from_member(TestClass, "voice")
+    assert sorted(values) == ["voice1", "voice2"]
+
+
+def test_extract_literal_values_from_member_missing_member():
+    """Test that extracting from non-existent member raises AttributeError."""
+    class TestClass:
+        voice: Literal["alloy", "echo"]
+    
+    with pytest.raises(AttributeError, match="Member 'missing' not found"):
+        extract_literal_values_from_member(TestClass, "missing")
+
+
+def test_extract_literal_values_from_member_non_literal():
+    """Test that extracting from non-Literal member raises TypeError."""
+    class TestClass:
+        voice: str
+    
+    with pytest.raises(TypeError, match="does not contain any Literal values"):
+        extract_literal_values_from_member(TestClass, "voice")
+
+
+def test_extract_literal_values_empty_literal():
+    """Test behavior with empty Literal (edge case)."""
+    # This is a bit of an edge case - empty Literal types are unusual
+    # but we should handle them gracefully
+    with pytest.raises(TypeError, match="No Literal values found"):
+        extract_literal_values_from_type(Union[str, int])  # No literals here

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,183 @@
+"""Unit tests for okcourse models."""
+
+import pytest
+from pathlib import Path
+from logging import INFO
+
+from okcourse.models import (
+    CourseLectureTopic,
+    CourseOutline,
+    CourseLecture,
+    CoursePromptSet,
+    CourseSettings,
+    CourseGenerationInfo,
+    Course,
+)
+
+
+def test_course_lecture_topic_creation():
+    """Test creating a CourseLectureTopic."""
+    topic = CourseLectureTopic(
+        number=1,
+        title="Introduction to Python",
+        subtopics=["Variables", "Data Types", "Control Flow"]
+    )
+    assert topic.number == 1
+    assert topic.title == "Introduction to Python"
+    assert len(topic.subtopics) == 3
+    assert "Variables" in topic.subtopics
+
+
+def test_course_lecture_topic_str():
+    """Test string representation of CourseLectureTopic."""
+    topic = CourseLectureTopic(
+        number=2,
+        title="Advanced Concepts",
+        subtopics=["Classes", "Inheritance"]
+    )
+    str_repr = str(topic)
+    assert "Lecture 2: Advanced Concepts" in str_repr
+    assert "Classes" in str_repr
+    assert "Inheritance" in str_repr
+
+
+def test_course_outline_creation():
+    """Test creating a CourseOutline."""
+    topics = [
+        CourseLectureTopic(number=1, title="Basics", subtopics=["Intro"]),
+        CourseLectureTopic(number=2, title="Advanced", subtopics=["Expert"])
+    ]
+    outline = CourseOutline(title="Python Course", topics=topics)
+    assert outline.title == "Python Course"
+    assert len(outline.topics) == 2
+    assert outline.topics[0].title == "Basics"
+
+
+def test_course_lecture_creation():
+    """Test creating a CourseLecture."""
+    lecture = CourseLecture(
+        number=1,
+        title="Introduction",
+        subtopics=["Overview"],
+        text="This is the lecture content."
+    )
+    assert lecture.number == 1
+    assert lecture.title == "Introduction"
+    assert lecture.text == "This is the lecture content."
+    assert "Overview" in lecture.subtopics
+
+
+def test_course_prompt_set_creation():
+    """Test creating a CoursePromptSet."""
+    prompt_set = CoursePromptSet(
+        description="Test prompts",
+        system="You are a teacher.",
+        outline="Create an outline.",
+        lecture="Generate a lecture.",
+        image="Create an image."
+    )
+    assert prompt_set.description == "Test prompts"
+    assert prompt_set.system == "You are a teacher."
+    assert prompt_set.outline == "Create an outline."
+
+
+def test_course_settings_defaults():
+    """Test default values in CourseSettings."""
+    settings = CourseSettings()
+    assert settings.num_lectures == 4
+    assert settings.num_subtopics == 4
+    assert settings.text_model_outline == "gpt-4o"
+    assert settings.text_model_lecture == "gpt-4o"
+    assert settings.image_model == "dall-e-3"
+    assert settings.tts_model == "tts-1"
+    assert settings.tts_voice == "alloy"
+    assert settings.log_level == INFO
+    assert settings.log_to_file is False
+
+
+def test_course_settings_custom_values():
+    """Test CourseSettings with custom values."""
+    settings = CourseSettings(
+        num_lectures=6,
+        num_subtopics=3,
+        text_model_outline="gpt-3.5-turbo",
+        output_directory=Path("/tmp/test")
+    )
+    assert settings.num_lectures == 6
+    assert settings.num_subtopics == 3
+    assert settings.text_model_outline == "gpt-3.5-turbo"
+    assert settings.output_directory == Path("/tmp/test")
+
+
+def test_course_generation_info_defaults():
+    """Test default values in CourseGenerationInfo."""
+    info = CourseGenerationInfo()
+    assert info.okcourse_version is None
+    assert info.generator_type is None
+    assert info.lecture_input_token_count == 0
+    assert info.lecture_output_token_count == 0
+    assert info.outline_input_token_count == 0
+    assert info.outline_output_token_count == 0
+    assert info.tts_character_count == 0
+    assert info.outline_gen_elapsed_seconds == 0.0
+    assert info.lecture_gen_elapsed_seconds == 0.0
+    assert info.image_gen_elapsed_seconds == 0.0
+    assert info.audio_gen_elapsed_seconds == 0.0
+    assert info.num_images_generated == 0
+    assert info.audio_file_path is None
+    assert info.image_file_path is None
+
+
+def test_course_creation():
+    """Test creating a Course."""
+    course = Course(title="Test Course")
+    assert course.title == "Test Course"
+    assert course.outline is None
+    assert course.lectures is None
+    assert isinstance(course.settings, CourseSettings)
+    assert isinstance(course.generation_info, CourseGenerationInfo)
+
+
+def test_course_with_outline():
+    """Test Course with an outline."""
+    topics = [CourseLectureTopic(number=1, title="Topic 1", subtopics=["Sub1"])]
+    outline = CourseOutline(title="Course Title", topics=topics)
+    course = Course(title="Test", outline=outline)
+    assert course.outline is not None
+    assert course.outline.title == "Course Title"
+    assert len(course.outline.topics) == 1
+
+
+def test_course_with_lectures():
+    """Test Course with lectures."""
+    lectures = [
+        CourseLecture(number=1, title="Lecture 1", subtopics=["Sub1"], text="Content 1"),
+        CourseLecture(number=2, title="Lecture 2", subtopics=["Sub2"], text="Content 2")
+    ]
+    course = Course(title="Test", lectures=lectures)
+    assert course.lectures is not None
+    assert len(course.lectures) == 2
+    assert course.lectures[0].title == "Lecture 1"
+    assert course.lectures[1].text == "Content 2"
+
+
+def test_course_str_without_lectures():
+    """Test Course string representation without lectures."""
+    topics = [CourseLectureTopic(number=1, title="Topic 1", subtopics=["Sub1"])]
+    outline = CourseOutline(title="Course Title", topics=topics)
+    course = Course(title="Test", outline=outline)
+    str_repr = str(course)
+    assert "Course title: Course Title" in str_repr
+    assert "Topic 1" in str_repr
+
+
+def test_course_str_with_lectures():
+    """Test Course string representation with lectures."""
+    topics = [CourseLectureTopic(number=1, title="Topic 1", subtopics=["Sub1"])]
+    outline = CourseOutline(title="Course Title", topics=topics)
+    lectures = [CourseLecture(number=1, title="Lecture 1", subtopics=["Sub1"], text="Content")]
+    course = Course(title="Test", outline=outline, lectures=lectures)
+    str_repr = str(course)
+    assert "Course title: Course Title" in str_repr
+    assert "Lecture 1" in str_repr
+    assert "Content" in str_repr


### PR DESCRIPTION
Created 3 new test files with 29 additional unit tests (bringing the total from 17 to 46 tests):

  tests/test_models.py (13 tests)

  - Tests for all core Pydantic models: CourseLectureTopic, CourseOutline, CourseLecture, CoursePromptSet, CourseSettings, CourseGenerationInfo, and Course
  - Covers model creation, default values, custom values, and string representations
  - Tests model relationships and inheritance

  tests/test_misc_utils.py (10 tests)

  - Tests for extract_literal_values_from_type() and extract_literal_values_from_member() functions
  - Covers various typing scenarios: simple Literals, Unions, Optional types, nested structures
  - Tests error conditions and edge cases

  tests/test_audio_utils.py (6 tests)

  - Tests for the _is_valid_mp3() helper function
  - Tests for combine_mp3_buffers() error validation (empty inputs, invalid data)
  - Focuses on testable logic without requiring actual MP3 files

## Output

```console
$ uv run pytest
===================================================== test session starts ======================================================
platform darwin -- Python 3.12.7, pytest-8.4.0, pluggy-1.6.0
rootdir: /Users/mmacy/repos/okcourse
configfile: pytest.ini
testpaths: tests
plugins: anyio-4.9.0
collected 46 items                                                                                                             

tests/test_audio_utils.py ......                                                                                         [ 13%]
tests/test_misc_utils.py ..........                                                                                      [ 34%]
tests/test_models.py .............                                                                                       [ 63%]
tests/test_string_utils.py .................                                                                             [100%]

====================================================== 46 passed in 0.33s =====================================================
```
